### PR TITLE
Specify VisionSDK Pod Version in Podspec & Upgrade Android VisionSDK for SDK 23 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ In the `build.gradle` file of your Android project, add the following dependenci
 ```gradle
 dependencies {
     // Existing dependencies
-    implementation 'com.github.packagexlabs:vision-sdk-android:v2.1.12'
+    implementation 'com.github.packagexlabs:vision-sdk-android:v2.1.13'
     implementation 'com.github.asadullahilyas:HandyUtils:1.1.6'
 }
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -140,7 +140,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 // From node_modules
-  implementation 'com.github.packagexlabs:vision-sdk-android:v2.1.12'
+  implementation 'com.github.packagexlabs:vision-sdk-android:v2.1.13'
   implementation 'com.github.asadullahilyas:HandyUtils:1.1.6'
 }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext {
     buildToolsVersion = "35.0.0"
-    minSdkVersion = 29
+    minSdkVersion = 24
     compileSdkVersion = 35
     targetSdkVersion = 35
     ndkVersion = "26.1.10909125"

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -11,13 +11,13 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "14.0" }
+  s.platforms    = { :ios => "16.0" }
   s.source       = { :git => "https://github.com/packagex-io/react-native-vision-sdk.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "VisionSDK"
+  s.dependency "VisionSDK", ">= 1.7.5"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then


### PR DESCRIPTION
Overview: 
This update improves dependency management and compatibility for both iOS and Android platforms.

Changes:

iOS Podspec Update:
The VisionSDK pod version is now explicitly specified in the podspec file. This means clients no longer need to manually declare the VisionSDK version in their Podfile, simplifying integration and ensuring consistency.

Android VisionSDK Upgrade:
The native Android VisionSDK has been upgraded to its latest version, ensuring compatibility with projects that use a minimum SDK version of 23.

These changes streamline dependency management and improve cross-platform compatibility.