### PR TITLE
chore: update peerDependencies for React Native 0.73+ and React 18+

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,8 +97,8 @@
     "@types/react": "18.2.28"
   },
   "peerDependencies": {
-    "react": ">=18.3.0",
-    "react-native": ">=0.74.5"
+    "react-native": ">=0.73.0",
+    "react": ">=18.0.0"
   },
   "engines": {
     "node": ">= 18.0.0"


### PR DESCRIPTION
This update adjusts our library’s peer dependencies to improve compatibility with current React Native projects. The changes are as follows:

React Native: Now requires >=0.73.0 to ensure usage with the latest features and improvements.

React: Set to >=18.0.0 without an enforced upper bound. This leverages the fact that newly initialized React Native projects automatically install a compatible React version.

By removing the upper bound for React, we reduce the need for workarounds like the legacy peer dependencies flag, streamlining the installation process for client projects.