### PR TITLE
fix: Convert dp to px for focusImageRect in FocusSettings (Android)

### DIFF
--- a/android/src/main/java/com/visionsdk/VisionSdkViewManager.kt
+++ b/android/src/main/java/com/visionsdk/VisionSdkViewManager.kt
@@ -234,12 +234,20 @@ class VisionSdkViewManager(private val appContext: ReactApplicationContext) :
             R.drawable.default_focus_frame
           ),
           focusImageRect = optJSONObject("focusImageRect")?.let {
-            RectF(
-              it.optDouble("x", 0.0).toFloat(),
-              it.optDouble("y", 0.0).toFloat(),
-              it.optDouble("x", 0.0).toFloat() + it.optDouble("width", 0.0).toFloat(),
-              it.optDouble("y", 0.0).toFloat() + it.optDouble("height", 0.0).toFloat()
-            )
+            val density = context?.resources?.displayMetrics?.density ?: 1.0f
+            // Extract dp values from JSON.
+            val xDip = it.optDouble("x", 0.0)
+            val yDip = it.optDouble("y", 0.0)
+            val widthDip = it.optDouble("width", 0.0)
+            val heightDip = it.optDouble("height", 0.0)
+
+            // Convert dp to pixels using your working approach.
+            val xPx = ((xDip * density.toDouble()).toFloat())
+            val yPx = ((yDip * density.toDouble()).toFloat())
+            val widthPx = ((widthDip * density.toDouble()).toFloat())
+            val heightPx = ((heightDip * density.toDouble()).toFloat())
+
+            RectF(xPx, yPx, xPx + widthPx, yPx + heightPx)
           } ?: RectF(0.0F, 0.0F, 0.0F, 0.0F),
           focusImageTintColor = optString("focusImageTintColor").ifNeitherNullNorEmptyNorBlank {
             hexColorToInt(it)

--- a/example/src/CameraScreen.tsx
+++ b/example/src/CameraScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { View, StyleSheet, Platform, Alert, Vibration } from 'react-native';
+import { View, StyleSheet, Platform, Alert, Vibration, useWindowDimensions } from 'react-native';
 import VisionSdkView, {
   VisionSdkRefProps,
   ModuleType,
@@ -74,6 +74,12 @@ const App: React.FC<{ route: any }> = ({ route }) => {
     document: false,
   });
 
+  const { width: screenWidth, height: screenHeight } = useWindowDimensions()
+const scannerWidth = screenWidth * 0.8;
+const scannerHeight = 160;
+const scannerX = (screenWidth - scannerWidth) / 2;
+const scannerY = (screenHeight - scannerHeight) / 2;
+
   const [modelDownloadingProgress, setModelDownloadingProgress] =
     useState<DownloadingProgress>({
       downloadStatus: false,
@@ -109,6 +115,8 @@ const App: React.FC<{ route: any }> = ({ route }) => {
         documentBoundaryFillColor: '#e3000080',
         focusImageTintColor: '#ffffff',
         focusImageHighlightedColor: '#e30000',
+        focusImageRect: { x: scannerX, y: scannerY, width: scannerWidth, height: scannerHeight },
+
       }
       visionSdk?.current?.setFocusSettings(focusSettings);
       visionSdk?.current?.setObjectDetectionSettings({


### PR DESCRIPTION
This PR updates the focusImageRect initialization in FocusSettings to convert
dp values to pixels correctly. Previously, the focus rectangle did not scale
properly on devices with different pixel densities.

Changes include:
- Extracting device density from context resources.
- Converting "x", "y", "width", and "height" from dp to pixels by multiplying with
  the device density.
- Providing a fallback default RectF when the JSON object is absent.

These changes ensure the focus rectangle appears correctly across various
device densities.
