### PR TITLE
chore: updated native ios sdk to 1.8.5

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1309,7 +1309,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-vision-sdk (1.4.6):
+  - react-native-vision-sdk (1.4.9):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1317,7 +1317,7 @@ PODS:
     - React-Core
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-    - VisionSDK (= 1.8.4)
+    - VisionSDK (= 1.8.5)
   - React-nativeconfig (0.76.6)
   - React-NativeModulesApple (0.76.6):
     - glog
@@ -1824,7 +1824,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - SocketRocket (0.7.1)
-  - VisionSDK (1.8.4)
+  - VisionSDK (1.8.5)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2091,7 +2091,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 89885d1518433a462fe64b68bf5e097997380090
   React-microtasksnativemodule: 36341e09dcd1df535503e6ed2ddf88f10da56d52
   react-native-safe-area-context: 5e53e2b0fc3a2994ad0c89a2486e545b6566d8c4
-  react-native-vision-sdk: 4809200f77dc77667473587064bcbdc933806619
+  react-native-vision-sdk: 1f10eafe8ef736c6a66a5b3150c9bbe937407503
   React-nativeconfig: 539ff4de6ce3b694e8e751080568c281c84903ce
   React-NativeModulesApple: 702246817c286d057e23fe4b1302019796e62521
   React-perflogger: f260e2de95f9dbd002035251559c13bf1f0643d4
@@ -2126,7 +2126,7 @@ SPEC CHECKSUMS:
   RNSVG: c50d29abf38abbf48ebfc50b6258f81099aeabae
   RNVectorIcons: a24016b773380b1aa37fca501ec6b94a951890a0
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  VisionSDK: 45b499bf3ee9df2d7c7f8fdb4cc65108d9c38e45
+  VisionSDK: ccad82f385bd8769310306e1cf6a61b004a6d0cc
   Yoga: be6f55a028e86c83ae066f018e9b5d24ffc45436
 
 PODFILE CHECKSUM: dc33509ec6a3d304fce4a84c03d57986d6a7860e

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "VisionSDK", "= 1.8.4"
+  s.dependency "VisionSDK", "= 1.8.5"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then


### PR DESCRIPTION
This PR updates native IOS sdk to version 1.8.5

The update fixes the following:
On device inference did not work correctly when switching from item_label to shipping_label model. 