### PR TITLE
feat: add shipping and item label logging APIs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -140,7 +140,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 // From node_modules
-  implementation 'com.github.packagexlabs:vision-sdk-android:v2.3.1'
+  implementation 'com.github.packagexlabs:vision-sdk-android:v2.3.3'
   implementation 'com.github.asadullahilyas:HandyUtils:1.1.6'
 }
 

--- a/android/src/main/java/com/visionsdk/VisionSdkModule.kt
+++ b/android/src/main/java/com/visionsdk/VisionSdkModule.kt
@@ -1,13 +1,26 @@
 package com.visionsdk
 
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import com.facebook.react.bridge.*
 import io.packagex.visionsdk.Environment
 import io.packagex.visionsdk.VisionSDK
 import io.packagex.visionsdk.ocr.ml.core.enums.ModelSize
 import io.packagex.visionsdk.ocr.ml.core.enums.OCRModule
+import io.packagex.visionsdk.ApiManager
 import kotlinx.coroutines.*
 import com.visionsdk.utils.EventUtils
+import io.packagex.visionsdk.exceptions.VisionSDKException
+import io.packagex.visionsdk.interfaces.OCRResult
+import io.packagex.visionsdk.interfaces.ResponseCallback
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
 
 class VisionSdkModule(private val reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
 
@@ -64,6 +77,135 @@ class VisionSdkModule(private val reactContext: ReactApplicationContext) : React
   }
 
   @ReactMethod
+  fun logItemLabelDataToPx(
+    imageUri: String,
+    barcodes: ReadableArray,
+    responseData: ReadableMap,
+    token: String?,
+    apiKey: String?,
+    shouldResizeImage: Boolean,
+    promise: Promise
+  ){
+   Log.d(TAG, "log item label data to px called")
+    val uri = Uri.parse(imageUri)
+    uriToBitmap(reactContext, uri) { bitmap ->
+      if (bitmap == null) {
+        promise.reject("BITMAP_ERROR", "Failed to decode image from URI: $imageUri")
+        return@uriToBitmap
+      }
+
+      try {
+        val barcodeList = mutableListOf<String>()
+        for (i in 0 until barcodes.size()) {
+          barcodeList.add(barcodes.getString(i) ?: "")
+        }
+
+        val dataMap = responseData.toHashMap()
+        val onDeviceResponse = (dataMap as Map<*, *>?)?.let { JSONObject(it).toString() } ?: ""
+
+        Log.d(TAG, "ondeviceresponse:\n $onDeviceResponse")
+
+        ApiManager().itemLabelMatchingApiCallAsync(
+          reactContext,
+          apiKey,
+          token,
+          bitmap,
+          shouldResizeImage,
+          barcodeList,
+          onDeviceResponse,
+          onResponseCallback =  object : ResponseCallback {
+            override fun onError(visionException: VisionSDKException) {
+              Log.e(TAG, "Item label match failed", visionException)
+              promise.reject("MATCH_FAILED", "Item label match failed: ${visionException.message}", visionException)
+            }
+
+            override fun onResponse(response: String) {
+              Log.d(TAG, "Item label match success: $response")
+              promise.resolve("Item label match successful: $response")
+            }
+          }
+
+          )
+      } catch (e: Exception) {
+        Log.e(TAG, "Exception in logItemLabelDataToPx", e)
+        promise.reject("PROCESSING_FAILED", "Error during processing: ${e.message}", e)
+      }
+    }
+  }
+
+  @ReactMethod
+  fun logShippingLabelDataToPx(
+    imageUri: String,
+    barcodes: ReadableArray,
+    responseData: ReadableMap,
+    token: String?,
+    apiKey: String?,
+    locationId: String?,
+    options: ReadableMap?,
+    metadata: ReadableMap?,
+    recipient: ReadableMap?,
+    sender: ReadableMap?,
+    shouldResizeImage: Boolean,
+    promise: Promise
+  ){
+    Log.d(TAG, "logShippingLabelDataToPx called with imageUri: $imageUri")
+
+    val uri = Uri.parse(imageUri)
+
+    uriToBitmap(reactContext, uri) { bitmap ->
+      if (bitmap == null) {
+        promise.reject("BITMAP_ERROR", "Failed to decode image from URI: $imageUri")
+        return@uriToBitmap
+      }
+
+      try {
+        val barcodeList = mutableListOf<String>()
+        for (i in 0 until barcodes.size()) {
+          barcodeList.add(barcodes.getString(i) ?: "")
+        }
+
+        val dataMap = responseData.toHashMap()
+        val onDeviceResponse = (dataMap as Map<*, *>?)?.let { JSONObject(it).toString() } ?: ""
+
+        Log.d(TAG, "ondeviceresponse:\n $onDeviceResponse")
+
+        val optionsMap = options?.toHashMap() ?: emptyMap()
+        val metadataMap = metadata?.toHashMap() ?: emptyMap()
+        val recipientMap = recipient?.toHashMap()
+        val senderMap = sender?.toHashMap()
+
+        ApiManager().shippingLabelMatchingApiAsync(
+          apiKey = apiKey,
+          token = token,
+          bitmap = bitmap,
+          shouldResizeImage = shouldResizeImage,
+          barcodeList = barcodeList,
+          onDeviceResponse = onDeviceResponse,
+          locationId = locationId,
+          recipient = recipientMap,
+          sender = senderMap,
+          options = optionsMap,
+          metadata = metadataMap,
+          onResponseCallback = object : ResponseCallback {
+            override fun onError(visionException: VisionSDKException) {
+              Log.e(TAG, "Shipping label match failed", visionException)
+              promise.reject("MATCH_FAILED", "Shipping label match failed: ${visionException.message}", visionException)
+            }
+
+            override fun onResponse(response: String) {
+              Log.d(TAG, "Shipping label match success: $response")
+              promise.resolve("Shipping label match successful: $response")
+            }
+          }
+        )
+      } catch (e: Exception) {
+        Log.e(TAG, "Exception in logShippingLabelDataToPx", e)
+        promise.reject("PROCESSING_FAILED", "Error during processing: ${e.message}", e)
+      }
+    }
+  }
+
+  @ReactMethod
   fun loadOnDeviceModels(
     token: String?,
     apiKey: String?,
@@ -109,4 +251,48 @@ class VisionSdkModule(private val reactContext: ReactApplicationContext) : React
       }
     }
   }
+
+  /**
+   * Converts a URI to a Bitmap.
+   * This function supports both HTTP/HTTPS URIs (for remote images) and local URIs.
+   * The result is posted back to the main UI thread through a callback.
+   *
+   * @param context - The application context, used to access content resolver for local URIs.
+   * @param uri - The URI to be converted to a Bitmap.
+   * @param onComplete - A callback function invoked with the Bitmap result on the main UI thread, or null if conversion fails.
+   */
+  private fun uriToBitmap(context: Context, uri: Uri, onComplete: (Bitmap?) -> Unit) {
+    Thread {
+      try {
+        val bitmap: Bitmap? = if (uri.scheme == "http" || uri.scheme == "https") {
+          // Handle HTTP/HTTPS URIs for remote images
+          val url = URL(uri.toString())
+          val connection: HttpURLConnection = url.openConnection() as HttpURLConnection
+          connection.doInput = true
+          connection.connect()
+
+          connection.inputStream.use { inputStream ->
+            BitmapFactory.decodeStream(inputStream)
+          }
+        } else {
+          // Handle local URIs (file, content, etc.)
+          context.contentResolver.openInputStream(uri)?.use { inputStream ->
+            BitmapFactory.decodeStream(inputStream)
+          } ?: null
+        }
+
+        // Post the result back to the main UI thread via the callback
+        Handler(Looper.getMainLooper()).post {
+          onComplete(bitmap)
+        }
+      } catch (e: Exception) {
+        e.printStackTrace()
+        // Post null to the callback on the main thread if there's an error
+        Handler(Looper.getMainLooper()).post {
+          onComplete(null)
+        }
+      }
+    }.start()  // Start the background thread
+  }
+
 }

--- a/android/src/main/java/com/visionsdk/VisionSdkViewManager.kt
+++ b/android/src/main/java/com/visionsdk/VisionSdkViewManager.kt
@@ -977,7 +977,7 @@ class VisionSdkViewManager(private val appContext: ReactApplicationContext) :
     lifecycleOwner?.lifecycle?.coroutineScope?.launchOnIO {
       try {
         val onDeviceResponse = getOnDeviceOCRResponse(bitmap, list) ?: return@launchOnIO
-        val result = ApiManager().matchingApiSync(
+        val result = ApiManager().shippingLabelMatchingApiSync(
           apiKey = resolvedApiKey,
           token = resolvedToken,
           bitmap = bitmap,
@@ -1672,7 +1672,7 @@ class VisionSdkViewManager(private val appContext: ReactApplicationContext) :
   }
 
   // Processes the OCR response, formats it, and sends it as a JavaScript event to React Native
-  override fun onOCRResponse(response: String?) {
+  override fun onOCRResponse(response: String) {
     Log.d(TAG, "api responded with  ${response}")
     val event = Arguments.createMap().apply {
       putString("data", JSONObject(response).toString())

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1317,7 +1317,7 @@ PODS:
     - React-Core
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-    - VisionSDK (= 1.8.5)
+    - VisionSDK (= 1.8.6)
   - React-nativeconfig (0.76.6)
   - React-NativeModulesApple (0.76.6):
     - glog
@@ -1824,7 +1824,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - SocketRocket (0.7.1)
-  - VisionSDK (1.8.5)
+  - VisionSDK (1.8.6)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2091,7 +2091,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 89885d1518433a462fe64b68bf5e097997380090
   React-microtasksnativemodule: 36341e09dcd1df535503e6ed2ddf88f10da56d52
   react-native-safe-area-context: 5e53e2b0fc3a2994ad0c89a2486e545b6566d8c4
-  react-native-vision-sdk: 1f10eafe8ef736c6a66a5b3150c9bbe937407503
+  react-native-vision-sdk: abe9cd639cd3edd52529b9a7fa69abf7c249d992
   React-nativeconfig: 539ff4de6ce3b694e8e751080568c281c84903ce
   React-NativeModulesApple: 702246817c286d057e23fe4b1302019796e62521
   React-perflogger: f260e2de95f9dbd002035251559c13bf1f0643d4
@@ -2126,7 +2126,7 @@ SPEC CHECKSUMS:
   RNSVG: c50d29abf38abbf48ebfc50b6258f81099aeabae
   RNVectorIcons: a24016b773380b1aa37fca501ec6b94a951890a0
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  VisionSDK: ccad82f385bd8769310306e1cf6a61b004a6d0cc
+  VisionSDK: 359a2549505b0f2045ae23c89752c37715d80d0d
   Yoga: be6f55a028e86c83ae066f018e9b5d24ffc45436
 
 PODFILE CHECKSUM: dc33509ec6a3d304fce4a84c03d57986d6a7860e

--- a/ios/VisionSdkModule.m
+++ b/ios/VisionSdkModule.m
@@ -9,4 +9,25 @@ RCT_EXTERN_METHOD(loadOnDeviceModels:(NSString * _Nullable)token
                   modelSize:(NSString * _Nullable)modelSize
                   resolver:(RCTPromiseResolveBlock)resolver
                   rejecter:(RCTPromiseRejectBlock)rejecter)
+RCT_EXTERN_METHOD(logItemLabelDataToPx:(NSString *)imageUri
+                  barcodes:(nullable NSArray<NSString *> *)barcode
+                  responseData:(nonnull NSDictionary *)responseData
+                  token:(nullable NSString *)token
+                  apiKey:(nullable NSString *)apiKey
+                  shouldResizeImage:(nonnull NSNumber *)shouldResizeImage
+                  resolver:(RCTPromiseResolveBlock)resolver
+                  rejecter:(RCTPromiseRejectBlock)rejecter)
+RCT_EXTERN_METHOD(logShippingLabelDataToPx:(NSString *)imageUri
+                  barcodes:(nullable NSArray<NSString *> *)barcodes
+                  responseData:(NSDictionary *)responseData
+                  token:(nullable NSString *)token
+                  apiKey:(nullable NSString *)apiKey
+                  locationId:(nullable NSString *)locationId
+                  options:(nullable NSDictionary *)options
+                  metadata:(nullable NSDictionary *)metaData
+                  recipient:(nullable NSDictionary *)recipient
+                  sender:(nullable NSDictionary *)sender
+                  shouldResizeImage:(nonnull NSNumber *)shouldResizeImage
+                  resolver:(RCTPromiseResolveBlock)resolver
+                  rejecter:(RCTPromiseRejectBlock)rejecter)
 @end

--- a/ios/VisionSdkModule.swift
+++ b/ios/VisionSdkModule.swift
@@ -110,4 +110,176 @@ class VisionSdkModule: RCTEventEmitter {
         }
       )
   }
+  
+  @objc func logShippingLabelDataToPx(
+    _ imageUri: String,
+    barcodes: [String]?,
+    responseData: [String: Any],
+    token: String?,
+    apiKey: String?,
+    locationId: String?,
+    options: [String : Any]? = nil,
+    metadata: [String : Any]? = nil,
+    recipient: [String : Any]? = nil,
+    sender: [String : Any]? = nil,
+    shouldResizeImage: NSNumber,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+    
+  ){
+    self.loadImage(from: imageUri){image in
+      guard let image = image else {
+        rejecter("image_load_failed", "Failed to load image from URI", nil)
+        return
+      }
+      
+      guard JSONSerialization.isValidJSONObject(responseData),
+            let responseDataJson = try? JSONSerialization.data(withJSONObject: responseData) else {
+        rejecter("invalid_response_data", "Could not serialize responseData to JSON", nil)
+        return
+      }
+      
+      let barcodeList = barcodes ?? []
+      let shouldResize = shouldResizeImage.boolValue
+      
+      VisionAPIManager.shared.callMatchingAPIWith(
+        image,
+        andBarcodes: barcodeList,
+        andApiKey: apiKey,
+        andToken: token,
+        withResponseData: responseDataJson,
+        andLocationId: (locationId ?? "").isEmpty ? nil : locationId,
+        andOptions: options ?? [:],
+        andMetaData: metadata ?? [:],
+        andRecipient: recipient ?? [:],
+        andSender: sender ?? [:],
+        withImageResizing: shouldResize
+      ) {data, error in
+        if let error = error {
+          print(error)
+          rejecter("sdk_error", "SDK call failed", error)
+        } else {
+          resolver("Logged successfully")
+        }
+      }
+      
+    }
+  }
+  
+  @objc func logItemLabelDataToPx(
+    _ imageUri: String,
+    barcodes: [String]?,
+    responseData: [String: Any],
+    token: String?,
+    apiKey: String?,
+    shouldResizeImage: NSNumber,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    self.loadImage(from: imageUri){image in
+      guard let image = image else {
+        rejecter("image_load_failed", "Could not load image from URI", nil)
+        return
+      }
+      // Ensure barcodes is a non-nil array
+      let barcodeList = barcodes ?? []
+      
+      // Convert responseData dictionary to JSON Data
+      guard JSONSerialization.isValidJSONObject(responseData),
+            let responseDataJson = try? JSONSerialization.data(withJSONObject: responseData) else {
+        rejecter("invalid_response_data", "Failed to convert responseData to JSON", nil)
+        return
+      }
+      
+      let shouldResize = shouldResizeImage.boolValue
+      
+      VisionAPIManager.shared.callItemLabelsMatchingAPIWith(
+        image,
+        andBarcodes: barcodeList,
+        andApiKey: apiKey,
+        andToken: token,
+        withResponseData: responseDataJson,
+        withImageResizing: shouldResize
+      ){data, error in
+          if let error = error {
+            print(error)
+          rejecter("sdk_error", "SDK call failed", error)
+          return
+          } else {
+            resolver("Logged successfully")
+          }
+      }
+      
+    }
+    
+
+  }
+
+  
+  
+  private func loadImage(from imagePath: String, completion: @escaping (UIImage?) -> Void) {
+      guard !imagePath.isEmpty else {
+          print("Image path is empty.")
+          completion(nil)
+          return
+      }
+
+      if imagePath.hasPrefix("http") {
+          // It's a remote URL
+          guard let remoteUrl = URL(string: imagePath) else {
+              print("Invalid remote URL.")
+              completion(nil)
+              return
+          }
+
+          // Load image from the remote URL
+          URLSession.shared.dataTask(with: remoteUrl) { data, response, error in
+              if let data = data, error == nil, let image = UIImage(data: data) {
+                  DispatchQueue.main.async {
+                      completion(image)
+                  }
+              } else {
+                  print("Error loading image from URL: \(error?.localizedDescription ?? "Unknown error")")
+                  DispatchQueue.main.async {
+                      completion(nil)
+                  }
+              }
+          }.resume()
+
+      } else {
+          // Handle local file
+          var adjustedImagePath = imagePath
+          if !adjustedImagePath.hasPrefix("file://") {
+              adjustedImagePath = "file://" + adjustedImagePath
+          }
+
+          guard let localUrl = URL(string: adjustedImagePath) else {
+              print("Invalid local URL.")
+              completion(nil)
+              return
+          }
+
+          if !FileManager.default.fileExists(atPath: localUrl.path) {
+              print("File does not exist at path: \(localUrl.path)")
+              completion(nil)
+              return
+          }
+
+          DispatchQueue.global(qos: .default).async {
+              if let data = try? Data(contentsOf: localUrl), let image = UIImage(data: data) {
+                  DispatchQueue.main.async {
+                      completion(image)
+                  }
+              } else {
+                  print("Failed to load image from local URL.")
+                  DispatchQueue.main.async {
+                      completion(nil)
+                  }
+              }
+          }
+      }
+  }
+
+  
+  
 }

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "VisionSDK", "= 1.8.5"
+  s.dependency "VisionSDK", "= 1.8.6"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then

--- a/src/VisionCore.tsx
+++ b/src/VisionCore.tsx
@@ -44,7 +44,64 @@ export const VisionCore = {
     return eventEmitter.addListener("onModelDownloadProgress", (event) => {
       callback(event.progress, event.downloadStatus, event.isReady);
     });
+  },
+
+  logItemLabelDataToPx: async (
+    imageUri: string,
+    barcodes: string[],
+    responseData: any,
+    token: string | null,
+    apiKey: string | null,
+    shouldResizeImage: boolean = true
+  ) => {
+    try {
+      const r = await VisionSdkModule.logItemLabelDataToPx(
+        imageUri,
+        barcodes,
+        responseData,
+        token,
+        apiKey,
+        shouldResizeImage
+      );
+      return r
+    } catch (error) {
+      throw error
+    }
+  },
+
+  logShippingLabelDataToPx: async (
+    imageUri: string,
+    barcodes: string[],
+    responseData: any,
+    token: string | null,
+    apiKey: string | null,
+    locationId: string | null,
+    options: {[key: string]: any} | null,
+    metadata: {[key: string]: any} | null,
+    recipient: {[key: string]: any} | null,
+    sender: {[key: string]: any} | null,
+    shouldResizeImage: boolean = true
+  ) => {
+
+    try {
+      const r = await VisionSdkModule.logShippingLabelDataToPx(
+        imageUri,
+        barcodes,
+        responseData,
+        token,
+        apiKey,
+        locationId,
+        options,
+        metadata,
+        recipient,
+        sender,
+        shouldResizeImage
+      )
+
+      return r
+    } catch(err){
+      throw err
+    }
+
   }
 }
-
-// export default VisionSdk

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ import {
   findNodeHandle,
   StyleSheet,
   DeviceEventEmitter,
-  Platform,
+  Platform
 } from 'react-native';
 import { VisionSdkView } from './VisionSdkViewManager';
 import {
@@ -29,6 +29,7 @@ import {
 
 export * from './types';
 export * from './VisionCore';
+
 
 // Camera component
 const Camera = forwardRef<VisionSdkRefProps, VisionSdkProps>(


### PR DESCRIPTION
This PR introduces new APIs for logging shipping and item label data to PackageX Vision:

- Adds `logItemLabelDataToPx` and `logShippingLabelDataToPx` methods to both Android and iOS
- Updates Vision SDK dependencies (Android v2.3.3, iOS v1.8.6)
- Improves image handling for both remote and local URIs
- Adds support for offline processing of shipping and item labels
- Updates example app to demonstrate new APIs

Testing:
- Verified logging functionality for both shipping and item labels
- Tested image processing with both remote and local images
- Confirmed proper error handling and promise rejections