### PR TITLE
Add metadata support to item label logging and update VisionSDK dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -140,7 +140,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 // From node_modules
-  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.9'
+  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.12'
   implementation 'com.github.asadullahilyas:HandyUtils:1.1.6'
 }
 

--- a/android/src/main/java/com/visionsdk/VisionSdkModule.kt
+++ b/android/src/main/java/com/visionsdk/VisionSdkModule.kt
@@ -84,6 +84,7 @@ class VisionSdkModule(private val reactContext: ReactApplicationContext) : React
     token: String?,
     apiKey: String?,
     shouldResizeImage: Boolean,
+    metadata: ReadableMap,
     promise: Promise
   ){
    Log.d(TAG, "log item label data to px called")
@@ -106,12 +107,12 @@ class VisionSdkModule(private val reactContext: ReactApplicationContext) : React
         Log.d(TAG, "ondeviceresponse:\n $onDeviceResponse")
 
         ApiManager().itemLabelMatchingApiCallAsync(
-          context = reactContext,
           apiKey = apiKey,
           token = token,
           bitmap = bitmap,
           shouldResizeImage = shouldResizeImage,
           barcodeList =  barcodeList,
+          metadata = metadata.toHashMap(),
           onDeviceResponse =  onDeviceResponse,
           onResponseCallback =  object : ResponseCallback {
             override fun onError(visionException: VisionSDKException) {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1309,7 +1309,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-vision-sdk (1.4.10):
+  - react-native-vision-sdk (1.5.9):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1317,7 +1317,7 @@ PODS:
     - React-Core
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-    - VisionSDK (= 1.8.6)
+    - VisionSDK (= 1.9.1)
   - React-nativeconfig (0.76.6)
   - React-NativeModulesApple (0.76.6):
     - glog
@@ -1824,7 +1824,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - SocketRocket (0.7.1)
-  - VisionSDK (1.8.6)
+  - VisionSDK (1.9.1)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2091,7 +2091,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 89885d1518433a462fe64b68bf5e097997380090
   React-microtasksnativemodule: 36341e09dcd1df535503e6ed2ddf88f10da56d52
   react-native-safe-area-context: 5e53e2b0fc3a2994ad0c89a2486e545b6566d8c4
-  react-native-vision-sdk: 4e0662fbc900b1c22c83d4d141fb9c038a64a798
+  react-native-vision-sdk: 101fd6981a77b01a061f929c34ff5cc51425b669
   React-nativeconfig: 539ff4de6ce3b694e8e751080568c281c84903ce
   React-NativeModulesApple: 702246817c286d057e23fe4b1302019796e62521
   React-perflogger: f260e2de95f9dbd002035251559c13bf1f0643d4
@@ -2126,7 +2126,7 @@ SPEC CHECKSUMS:
   RNSVG: c50d29abf38abbf48ebfc50b6258f81099aeabae
   RNVectorIcons: a24016b773380b1aa37fca501ec6b94a951890a0
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  VisionSDK: 359a2549505b0f2045ae23c89752c37715d80d0d
+  VisionSDK: d03ff9060bba1123146d3767ac0a912cc316cc52
   Yoga: be6f55a028e86c83ae066f018e9b5d24ffc45436
 
 PODFILE CHECKSUM: dc33509ec6a3d304fce4a84c03d57986d6a7860e

--- a/example/src/CameraScreen.tsx
+++ b/example/src/CameraScreen.tsx
@@ -370,7 +370,7 @@ const App: React.FC<{ route: any }> = ({ route }) => {
         apiKey,
         null,
         null,
-        null,
+        {meta1: 'metaval1', meta2: 'metaval2'},
         null,
         null,
         true
@@ -391,7 +391,8 @@ const App: React.FC<{ route: any }> = ({ route }) => {
         { data: ocrEvent.data },
         null,
         apiKey,
-        true
+        true,
+        {meta1: 'metaval1', meta2: 'metaval2'}
       )
 
       console.log("IL SYNC SUCCESSFUL: ", r)

--- a/example/src/utils/index.ts
+++ b/example/src/utils/index.ts
@@ -1,0 +1,137 @@
+import { Platform } from 'react-native'
+import { VisionCore } from '../../../src/index'
+
+export const syncWithPx = async (scanResult, modelName, env, apiKey) => {
+    console.log("INISIDE SYNC WITH PX FUNCTION, SCANRESULT IS: ", JSON.stringify(scanResult))
+    try {
+
+        const updatedScanResult = JSON.parse(JSON.stringify(scanResult))
+
+        if (env !== 'prod') {
+            VisionCore.setEnvironment(env)
+        } else {
+            VisionCore.setEnvironment('production')
+        }
+
+        if (modelName === 'shipping-label') {
+
+            let formatedImageUrl = updatedScanResult?.image_url ?? "" // formatImageUrl(updatedData.image_url) : ''
+            if (formatedImageUrl && Platform.OS === 'android' && !formatedImageUrl.startsWith('file')) {
+                formatedImageUrl = `file://${formatedImageUrl}`
+            }
+
+            updatedScanResult.image_url = formatedImageUrl
+
+            // console.log("FORMATTED IMAGE URL IS: \n", formatedImageUrl)
+            // console.log("UPDATED SCAN RESULT IS: \n", JSON.stringify(updatedScanResult))
+
+
+
+            const r = await VisionCore.logShippingLabelDataToPx(
+                formatedImageUrl ?? '',
+                [],
+                {
+                    data: updatedScanResult
+                },
+                null,
+                apiKey,
+                '',
+                null,
+                {
+                    meta1: 'metaval1',
+                    meta2: 'metaval2'
+                },
+                null,
+                null,
+                true
+            )
+
+        } else if (modelName === 'item-label') {
+            // updatedScanResult.inference.item.sku = []
+            // updatedScanResult.inference.customer.sku = []
+            updatedScanResult.inference.item.quantity = updatedScanResult.inference.item.quantity ?
+                updatedScanResult.inference.item.quantity.map((item) => parseFloat(item)) : []
+            if (updatedScanResult.inference.item.weight.value) {
+                updatedScanResult.inference.item.weight.value = parseFloat(updatedScanResult.inference.item.weight.value)
+            }
+            if (updatedScanResult.inference.package.weight.value) {
+                updatedScanResult.inference.package.weight.value = parseFloat(updatedScanResult.inference.package.weight.value)
+            }
+
+            if (updatedScanResult.inference.dates.manufacturing.year) {
+                updatedScanResult.inference.dates.manufacturing.year = parseInt(updatedScanResult.inference.dates.manufacturing.year)
+            }
+
+            if (updatedScanResult.inference.dates.manufacturing.month) {
+                updatedScanResult.inference.dates.manufacturing.month = parseInt(updatedScanResult.inference.dates.manufacturing.month)
+            }
+
+            if (updatedScanResult.inference.dates.manufacturing.day) {
+                updatedScanResult.inference.dates.manufacturing.day = parseInt(updatedScanResult.inference.dates.manufacturing.day)
+            }
+            if (updatedScanResult.inference.dates.expiry.year) {
+                updatedScanResult.inference.dates.expiry.year = parseInt(updatedScanResult.inference.dates.expiry.year)
+            }
+            if (updatedScanResult.inference.dates.expiry.month) {
+                updatedScanResult.inference.dates.expiry.month = parseInt(updatedScanResult.inference.dates.expiry.month)
+            }
+            if (updatedScanResult.inference.dates.expiry.day) {
+                updatedScanResult.inference.dates.expiry.day = parseInt(updatedScanResult.inference.dates.expiry.day)
+            }
+
+            if (updatedScanResult.inference.item.dimensions.length.value) {
+                updatedScanResult.inference.item.dimensions.length.value = parseFloat(updatedScanResult.inference.item.dimensions.length.value)
+            }
+            if (updatedScanResult.inference.item.dimensions.width.value) {
+                updatedScanResult.inference.item.dimensions.width.value = parseFloat(updatedScanResult.inference.item.dimensions.width.value)
+            }
+            if (updatedScanResult.inference.item.dimensions.height.value) {
+                updatedScanResult.inference.item.dimensions.height.value = parseFloat(updatedScanResult.inference.item.dimensions.height.value)
+            }
+
+            if (updatedScanResult.inference.package.dimensions.length.value) {
+                updatedScanResult.inference.package.dimensions.length.value = parseFloat(updatedScanResult.inference.package.dimensions.length.value)
+            }
+            if (updatedScanResult.inference.package.dimensions.width.value) {
+                updatedScanResult.inference.package.dimensions.width.value = parseFloat(updatedScanResult.inference.package.dimensions.width.value)
+            }
+            if (updatedScanResult.inference.package.dimensions.height.value) {
+                updatedScanResult.inference.package.dimensions.height.value = parseFloat(updatedScanResult.inference.package.dimensions.height.value)
+            }
+
+
+
+            let formatedImageUrl = updatedScanResult?.image_url ?? "" // formatImageUrl(updatedData.image_url) : ''
+
+            if (formatedImageUrl && Platform.OS === 'android' && !formatedImageUrl.startsWith("file")) {
+                formatedImageUrl = `file://${formatedImageUrl}`
+            }
+
+
+            updatedScanResult.image_url = formatedImageUrl
+
+            if (updatedScanResult.custom) {
+                Object.keys(updatedScanResult.custom).forEach(key => {
+                    updatedScanResult.inference.additional_attributes[key] = updatedScanResult.custom[key]
+                    updatedScanResult.inference.additionalAttributes[key] = updatedScanResult.custom[key]
+                })
+            }
+
+            const r = await VisionCore.logItemLabelDataToPx(
+                formatedImageUrl ?? '',
+                [],
+                { data: updatedScanResult },
+                null,
+                apiKey,
+                true,
+                { meta1: 'meta1val', meta2: 'meta2val' }
+            )
+        } else {
+            return true
+        }
+
+    } catch (err) {
+        console.log("AN ERROR OCCURED [syncpx]: ", err.message)
+        throw err
+    }
+}

--- a/ios/VisionSdkModule.m
+++ b/ios/VisionSdkModule.m
@@ -15,6 +15,7 @@ RCT_EXTERN_METHOD(logItemLabelDataToPx:(NSString *)imageUri
                   token:(nullable NSString *)token
                   apiKey:(nullable NSString *)apiKey
                   shouldResizeImage:(nonnull NSNumber *)shouldResizeImage
+                  metadata:(nullable NSDictionary *)metadata
                   resolver:(RCTPromiseResolveBlock)resolver
                   rejecter:(RCTPromiseRejectBlock)rejecter)
 RCT_EXTERN_METHOD(logShippingLabelDataToPx:(NSString *)imageUri
@@ -24,7 +25,7 @@ RCT_EXTERN_METHOD(logShippingLabelDataToPx:(NSString *)imageUri
                   apiKey:(nullable NSString *)apiKey
                   locationId:(nullable NSString *)locationId
                   options:(nullable NSDictionary *)options
-                  metadata:(nullable NSDictionary *)metaData
+                  metadata:(nullable NSDictionary *)metadata
                   recipient:(nullable NSDictionary *)recipient
                   sender:(nullable NSDictionary *)sender
                   shouldResizeImage:(nonnull NSNumber *)shouldResizeImage

--- a/ios/VisionSdkModule.swift
+++ b/ios/VisionSdkModule.swift
@@ -173,6 +173,7 @@ class VisionSdkModule: RCTEventEmitter {
     token: String?,
     apiKey: String?,
     shouldResizeImage: NSNumber,
+    metadata: [String : Any]? = nil,
     resolver: @escaping RCTPromiseResolveBlock,
     rejecter: @escaping RCTPromiseRejectBlock
   ) {
@@ -192,6 +193,7 @@ class VisionSdkModule: RCTEventEmitter {
       }
       
       let shouldResize = shouldResizeImage.boolValue
+
       
       VisionAPIManager.shared.callItemLabelsMatchingAPIWith(
         image,
@@ -199,7 +201,8 @@ class VisionSdkModule: RCTEventEmitter {
         andApiKey: apiKey,
         andToken: token,
         withResponseData: responseDataJson,
-        withImageResizing: shouldResize
+        withImageResizing: shouldResize,
+        andMetaData: metadata ?? [:]
       ){data, error in
           if let error = error {
             print(error)

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "VisionSDK", "= 1.8.6"
+  s.dependency "VisionSDK", "= 1.9.1"
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then

--- a/src/VisionCore.tsx
+++ b/src/VisionCore.tsx
@@ -52,7 +52,8 @@ export const VisionCore = {
     responseData: any,
     token: string | null,
     apiKey: string | null,
-    shouldResizeImage: boolean = true
+    shouldResizeImage: boolean = true,
+    metadata: {[key: string]: any} | null = {},
   ) => {
     try {
       const r = await VisionSdkModule.logItemLabelDataToPx(
@@ -61,7 +62,8 @@ export const VisionCore = {
         responseData,
         token,
         apiKey,
-        shouldResizeImage
+        shouldResizeImage,
+        metadata
       );
       return r
     } catch (error) {


### PR DESCRIPTION
This pull request introduces the following changes:

Adds a metadata parameter to item label logging methods across Android and iOS native modules, the JS bridge, and the example app.
Updates VisionSDK and react-native-vision-sdk dependencies to the latest versions:
Android: vision-sdk-android updated to v2.4.12
iOS: VisionSDK updated to 1.9.1
Updates the example usage in CameraScreen.tsx to demonstrate passing metadata.
Fixes parameter naming and bridging issues in the iOS native module.

Why?
Enables passing custom metadata for item label logging, improving flexibility and integration.
Keeps dependencies up to date for bug fixes and new features.

Testing:
Verified that item label logging works as expected with the new metadata parameter on both platforms.
Example app updated and tested to ensure correct metadata handling.