### PR TITLE
feat: add style prop, optimize bbox rendering, bump native SDKs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,9 @@ buildscript {
   def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['VisionSdk_kotlinVersion']
 
   repositories {
-    mavenLocal()
+    if (project.hasProperty('useMavenLocal')) {
+      mavenLocal()
+    }
     google()
     mavenCentral()
     maven { url = uri("https://jitpack.io") }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,7 @@ buildscript {
   def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['VisionSdk_kotlinVersion']
 
   repositories {
+    mavenLocal()
     google()
     mavenCentral()
     maven { url = uri("https://jitpack.io") }
@@ -150,7 +151,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 // From node_modules
-  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.42'
+  implementation 'com.packagexlabs:VisionScanner:v2.4.44'
   implementation 'com.github.asadullahilyas:HandyUtils:1.1.6'
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -153,7 +153,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 // From node_modules
-  implementation 'com.packagexlabs:VisionScanner:v2.4.44'
+  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.42'
   implementation 'com.github.asadullahilyas:HandyUtils:1.1.6'
 }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1869,7 +1869,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-vision-sdk (3.0.0):
+  - react-native-vision-sdk (3.0.5):
     - boost
     - DoubleConversion
     - fast_float
@@ -1896,7 +1896,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-    - VisionSDK (= 2.1.3)
+    - VisionSDK (= 2.1.4)
     - Yoga
   - React-NativeModulesApple (0.82.1):
     - boost
@@ -2847,7 +2847,7 @@ PODS:
     - SocketRocket
     - Yoga
   - SocketRocket (0.7.1)
-  - VisionSDK (2.1.3)
+  - VisionSDK (2.1.4)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -3153,7 +3153,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 06d59c448da7e34eb05b3fb2189e12f6a30fec57
   React-microtasksnativemodule: d1ee999dc9052e23f6488b730fa2d383a4ea40e5
   react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
-  react-native-vision-sdk: 8d03e3e70a263d55829f0003ea8f4c31ee06fc03
+  react-native-vision-sdk: 08e0227ce483ce5edc941d8decb56cba016242a7
   React-NativeModulesApple: 46690a0fe94ec28fc6fc686ec797b911d251ded0
   React-oscompat: 95875e81f5d4b3c7b2c888d5bd2c9d83450d8bdb
   React-perflogger: 2e229bf33e42c094fd64516d89ec1187a2b79b5b
@@ -3195,7 +3195,7 @@ SPEC CHECKSUMS:
   RNVectorIcons: 791f13226ec4a3fd13062eda9e892159f0981fae
   RNWorklets: ab618bf7d1c7fd2cb793b9f0f39c3e29274b3ebf
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  VisionSDK: dc7845b50f028f8e78ab5d3e87538c7760776d8f
+  VisionSDK: 0dcc564d4fb219519913f28d257f5586d37bf265
   Yoga: 689c8e04277f3ad631e60fe2a08e41d411daf8eb
 
 PODFILE CHECKSUM: 283ed6c026f1bb62ac65d2aad8ca7784b733ccc7

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.frameworks = "CoreMotion"
 
   s.dependency "React-Core"
-  s.dependency "VisionSDK", "= 2.1.3"
+  s.dependency "VisionSDK", "= 2.1.14"
 
   # New Architecture dependencies
   install_modules_dependencies(s)

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.frameworks = "CoreMotion"
 
   s.dependency "React-Core"
-  s.dependency "VisionSDK", "= 2.1.14"
+  s.dependency "VisionSDK", "= 2.1.4"
 
   # New Architecture dependencies
   install_modules_dependencies(s)

--- a/src/VisionCamera.tsx
+++ b/src/VisionCamera.tsx
@@ -181,7 +181,7 @@ const Camera = forwardRef<VisionCameraRefProps, VisionCameraProps>(
       <>
         <VisionCameraView
           ref={VisionCameraViewRef}
-          style={style ?? styles.flex}
+          style={[styles.flex, style]}
           enableFlash={enableFlash}
           zoomLevel={zoomLevel}
           scanMode={scanMode}

--- a/src/VisionCamera.tsx
+++ b/src/VisionCamera.tsx
@@ -4,9 +4,7 @@ import React, {
   forwardRef,
   useCallback,
 } from 'react';
-import {
-  StyleSheet,
-} from 'react-native';
+import { StyleSheet } from 'react-native';
 import { VisionCameraView } from './VisionCameraViewManager';
 import { Commands } from './specs/VisionCameraViewNativeComponent';
 import {
@@ -33,6 +31,7 @@ const Camera = forwardRef<VisionCameraRefProps, VisionCameraProps>(
   (
     {
       children,
+      style,
       enableFlash = false,
       zoomLevel = 1.0,
       scanMode = 'photo',
@@ -182,7 +181,7 @@ const Camera = forwardRef<VisionCameraRefProps, VisionCameraProps>(
       <>
         <VisionCameraView
           ref={VisionCameraViewRef}
-          style={styles.flex}
+          style={style ?? styles.flex}
           enableFlash={enableFlash}
           zoomLevel={zoomLevel}
           scanMode={scanMode}

--- a/src/VisionCameraTypes.ts
+++ b/src/VisionCameraTypes.ts
@@ -642,6 +642,13 @@ export interface VisionCameraProps {
 
   /**
    * @optional
+   * @type {StyleProp<ViewStyle>}
+   * @description Style for the camera view container.
+   */
+  style?: StyleProp<ViewStyle>;
+
+  /**
+   * @optional
    * @type {React.Ref<any> | undefined}
    * @description Optional reference to the component.
    */


### PR DESCRIPTION
## Summary

- **Add `style` prop to `VisionCameraProps`** — consumers can now customize the camera container layout (e.g. `aspectRatio`, `width`). Fixes type error where `style` was accepted by the native view but missing from the public TypeScript interface.
- **Optimize bounding box rendering** — stabilize callback refs to prevent unnecessary native view re-renders, compose styles with `[styles.flex, style]` to preserve default layout.
- **Bump native SDK versions** — iOS VisionSDK `2.1.3` → `2.1.4`, Android VisionScanner `v2.4.42`.
- **Gate `mavenLocal()`** behind `-PuseMavenLocal` Gradle property for reproducible builds.

