### PR TITLE
Bump VisionSDK 2.2.0 + fix front camera on initial mount

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1869,7 +1869,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-vision-sdk (3.0.5):
+  - react-native-vision-sdk (3.0.7):
     - boost
     - DoubleConversion
     - fast_float
@@ -1896,7 +1896,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-    - VisionSDK (= 2.1.4)
+    - VisionSDK (= 2.2.0)
     - Yoga
   - React-NativeModulesApple (0.82.1):
     - boost
@@ -2847,7 +2847,7 @@ PODS:
     - SocketRocket
     - Yoga
   - SocketRocket (0.7.1)
-  - VisionSDK (2.1.4)
+  - VisionSDK (2.2.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -3153,7 +3153,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 06d59c448da7e34eb05b3fb2189e12f6a30fec57
   React-microtasksnativemodule: d1ee999dc9052e23f6488b730fa2d383a4ea40e5
   react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
-  react-native-vision-sdk: 08e0227ce483ce5edc941d8decb56cba016242a7
+  react-native-vision-sdk: e9fc4deb391e2079b613892b1f6b0d969e93c06c
   React-NativeModulesApple: 46690a0fe94ec28fc6fc686ec797b911d251ded0
   React-oscompat: 95875e81f5d4b3c7b2c888d5bd2c9d83450d8bdb
   React-perflogger: 2e229bf33e42c094fd64516d89ec1187a2b79b5b
@@ -3195,7 +3195,7 @@ SPEC CHECKSUMS:
   RNVectorIcons: 791f13226ec4a3fd13062eda9e892159f0981fae
   RNWorklets: ab618bf7d1c7fd2cb793b9f0f39c3e29274b3ebf
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  VisionSDK: 0dcc564d4fb219519913f28d257f5586d37bf265
+  VisionSDK: 88414bcbd92a36af740e96cb9fcf18270014936a
   Yoga: 689c8e04277f3ad631e60fe2a08e41d411daf8eb
 
 PODFILE CHECKSUM: 283ed6c026f1bb62ac65d2aad8ca7784b733ccc7

--- a/ios/RNVisionCameraView.swift
+++ b/ios/RNVisionCameraView.swift
@@ -626,9 +626,12 @@ class RNVisionCameraView: UIView {
   
   private func updateFrameSkip() {
     guard let cameraView = cameraView, let frameSkip = frameSkip else { return }
-    
+
     let cameraSettings = VisionSDK.CodeScannerView.CameraSettings()
     cameraSettings.nthFrameToProcess = frameSkip.int64Value
+    if let facingString = cameraFacing?.lowercased {
+      cameraSettings.cameraPosition = facingString == "front" ? .front : .back
+    }
     cameraView.setCameraSettingsTo(cameraSettings)
   }
   

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.frameworks = "CoreMotion"
 
   s.dependency "React-Core"
-  s.dependency "VisionSDK", "= 2.1.4"
+  s.dependency "VisionSDK", "= 2.2.0"
 
   # New Architecture dependencies
   install_modules_dependencies(s)


### PR DESCRIPTION
## Summary
- Bumps native iOS VisionSDK dependency from 2.1.4 to 2.2.0
- Fixes front camera not opening on initial mount when `cameraFacing="front"` is passed as a prop

## Bug Fix
`updateFrameSkip()` was creating a new `CameraSettings()` with default `cameraPosition` (`.back`), overwriting the front camera setting applied by `applyInitialCameraSettings()` during the `layoutSubviews` sequence. Fixed by preserving the current `cameraFacing` prop in the settings object.

