### PR TITLE
fix: expose rescan() + fix duplicate-bind multi-capture; surface normalizedBoundingBox

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -153,7 +153,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 // From node_modules
-  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.42'
+  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.45'
   implementation 'com.github.asadullahilyas:HandyUtils:1.1.6'
 }
 

--- a/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
+++ b/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
@@ -377,18 +377,22 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
     }
 
     override fun start(view: VisionCameraView) {
-        // Guard against duplicate start. The Fabric `onAfterUpdateTransaction` already
-        // calls startCamera() on first mount; a follow-up Commands.start() from JS would
-        // re-call startCamera(), which internally tears down the previewView and analyzer
-        // and re-adds them. That detaches the bound CameraX session — the existing
-        // `imageCaptureUseCase` is left orphaned and the next takePicture() fails with
-        // "Not bound to a valid Camera". Skipping when already started keeps the session
-        // intact.
-        if (view.isCameraStarted()) {
-            Log.d(TAG, "start called - camera already started, ignoring")
+        // Guard against duplicate start. Fabric's `onAfterUpdateTransaction` schedules
+        // the initial `startCamera()` via `view.post`, so on a fast mount+start sequence
+        // a JS-triggered `Commands.start()` can land BEFORE the posted runnable executes.
+        // At that point `isCameraStarted()` still returns false but `hasStarted` was
+        // already set synchronously by `onAfterUpdateTransaction`, so check both.
+        // Without this, `startCamera()` runs twice — second pass tears down PreviewView's
+        // surface, orphans `imageCaptureUseCase`, next takePicture() fails with
+        // "Not bound to a valid Camera".
+        if (hasStarted || view.isCameraStarted()) {
+            Log.d(TAG, "start called - camera already started or scheduled, ignoring")
             return
         }
-        Log.d(TAG, "start called")
+        Log.d(TAG, "start called - starting")
+        // Mark scheduled synchronously so a subsequent `onAfterUpdateTransaction` won't
+        // queue a second startCamera either.
+        hasStarted = true
         view.startCamera()
     }
 

--- a/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
+++ b/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
@@ -349,6 +349,7 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
             "capture" -> capture(root)
             "stop" -> stop(root)
             "start" -> start(root)
+            "rescan" -> rescan(root)
             "toggleFlash" -> {
                 val enabled = args?.getBoolean(0) ?: false
                 toggleFlash(root, enabled)
@@ -376,8 +377,24 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
     }
 
     override fun start(view: VisionCameraView) {
+        // Guard against duplicate start. The Fabric `onAfterUpdateTransaction` already
+        // calls startCamera() on first mount; a follow-up Commands.start() from JS would
+        // re-call startCamera(), which internally tears down the previewView and analyzer
+        // and re-adds them. That detaches the bound CameraX session — the existing
+        // `imageCaptureUseCase` is left orphaned and the next takePicture() fails with
+        // "Not bound to a valid Camera". Skipping when already started keeps the session
+        // intact.
+        if (view.isCameraStarted()) {
+            Log.d(TAG, "start called - camera already started, ignoring")
+            return
+        }
         Log.d(TAG, "start called")
         view.startCamera()
+    }
+
+    override fun rescan(view: VisionCameraView) {
+        Log.d(TAG, "rescan called")
+        view.rescan()
     }
 
     override fun toggleFlash(view: VisionCameraView, enabled: Boolean) {

--- a/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
+++ b/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
@@ -313,9 +313,28 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
 
     @ReactProp(name = "detectionConfigJson")
     override fun setDetectionConfigJson(view: VisionCameraView, configJson: String?) {
-        Log.d(TAG, "setDetectionConfig")
-        // Parse JSON and configure ObjectDetectionConfiguration
-        // TODO: Implement using ObjectDetectionConfiguration
+        Log.d(TAG, "setDetectionConfig: $configJson")
+        // Empty/null → keep SDK defaults (all detectors on) for backwards compat.
+        if (configJson.isNullOrEmpty()) return
+        try {
+            val obj = org.json.JSONObject(configJson)
+            // When consumer passes a config, opt-in semantics: anything not
+            // explicitly true is off. This is critical on Photo mode — without
+            // it the SDK runs MLKit text recognition on every frame, queuing
+            // 1.5×W×H byte[] InputImages internally and OOM'ing within seconds.
+            view.setObjectDetectionConfiguration(
+                io.packagex.visionsdk.config.ObjectDetectionConfiguration(
+                    isTextIndicationOn = obj.optBoolean("text", false),
+                    isBarcodeOrQRCodeIndicationOn =
+                        obj.optBoolean("barcode", false) ||
+                            obj.optBoolean("qrcode", false) ||
+                            obj.optBoolean("qrCode", false),
+                    isDocumentIndicationOn = obj.optBoolean("document", false),
+                ),
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to parse detectionConfig JSON", e)
+        }
     }
 
     @ReactProp(name = "templateJson")

--- a/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
+++ b/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
@@ -508,6 +508,16 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
                         })
                     }
 
+                    // 0–1 normalized rect in image coordinates, top-left origin.
+                    // Use this when overlaying on the captured image — it survives
+                    // aspect-ratio differences between preview and saved photo.
+                    put("normalizedBoundingBox", org.json.JSONObject().apply {
+                        put("x", code.normalizedBoundingBox.left.toDouble())
+                        put("y", code.normalizedBoundingBox.top.toDouble())
+                        put("width", code.normalizedBoundingBox.width().toDouble())
+                        put("height", code.normalizedBoundingBox.height().toDouble())
+                    })
+
                     if (!code.gs1ExtractedInfo.isNullOrEmpty()) {
                         val gs1Obj = org.json.JSONObject()
                         code.gs1ExtractedInfo?.forEach { (key, value) ->
@@ -601,6 +611,14 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
                             put("height", box.height().toDp(density))
                         })
                     }
+
+                    // 0–1 normalized rect in image coordinates, top-left origin.
+                    put("normalizedBoundingBox", org.json.JSONObject().apply {
+                        put("x", code.normalizedBoundingBox.left.toDouble())
+                        put("y", code.normalizedBoundingBox.top.toDouble())
+                        put("width", code.normalizedBoundingBox.width().toDouble())
+                        put("height", code.normalizedBoundingBox.height().toDouble())
+                    })
                 }
                 barcodeRectsJsonArray.put(boxObj)
             }
@@ -628,6 +646,14 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
                             put("height", box.height().toDp(density))
                         })
                     }
+
+                    // 0–1 normalized rect in image coordinates, top-left origin.
+                    put("normalizedBoundingBox", org.json.JSONObject().apply {
+                        put("x", code.normalizedBoundingBox.left.toDouble())
+                        put("y", code.normalizedBoundingBox.top.toDouble())
+                        put("width", code.normalizedBoundingBox.width().toDouble())
+                        put("height", code.normalizedBoundingBox.height().toDouble())
+                    })
                 }
                 qrCodeRectsJsonArray.put(boxObj)
             }
@@ -695,6 +721,14 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
                                 put("height", box.height().toDouble())
                             })
                         }
+
+                        // 0–1 normalized rect in image coordinates, top-left origin.
+                        put("normalizedBoundingBox", org.json.JSONObject().apply {
+                            put("x", code.normalizedBoundingBox.left.toDouble())
+                            put("y", code.normalizedBoundingBox.top.toDouble())
+                            put("width", code.normalizedBoundingBox.width().toDouble())
+                            put("height", code.normalizedBoundingBox.height().toDouble())
+                        })
 
                         if (!code.gs1ExtractedInfo.isNullOrEmpty()) {
                             val gs1Obj = org.json.JSONObject()

--- a/android/src/newarch/java/com/visionsdk/VisionSdkModule.kt
+++ b/android/src/newarch/java/com/visionsdk/VisionSdkModule.kt
@@ -1452,6 +1452,21 @@ class VisionSdkModule(reactContext: ReactApplicationContext) :
                             Rect(0, 0, 0, 0)
                         }
 
+                        // Read "normalizedBoundingBox" (0–1 normalized, top-left origin) so the OCR
+                        // path can crop the captured image around each barcode without depending on
+                        // preview-pixel coords. Falls back to empty RectF if not provided
+                        // (consumers on older SDK versions).
+                        val normalizedBoundingBoxMap = barcodeMap.getMap("normalizedBoundingBox")
+                        val normalizedRect = if (normalizedBoundingBoxMap != null) {
+                            val nx = normalizedBoundingBoxMap.getDouble("x").toFloat()
+                            val ny = normalizedBoundingBoxMap.getDouble("y").toFloat()
+                            val nw = normalizedBoundingBoxMap.getDouble("width").toFloat()
+                            val nh = normalizedBoundingBoxMap.getDouble("height").toFloat()
+                            android.graphics.RectF(nx, ny, nx + nw, ny + nh)
+                        } else {
+                            android.graphics.RectF()
+                        }
+
                         // Convert symbology string to BarcodeSymbology enum
                         val barcodeSymbology = when (symbology.lowercase()) {
                             "code_128", "code128" -> BarcodeSymbology.code128
@@ -1475,7 +1490,8 @@ class VisionSdkModule(reactContext: ReactApplicationContext) :
                                 scannedCode = value,
                                 symbology = barcodeSymbology,
                                 boundingBox = rect,
-                                gs1ExtractedInfo = gs1ExtractedInfo
+                                gs1ExtractedInfo = gs1ExtractedInfo,
+                                normalizedBoundingBox = normalizedRect
                             )
                         )
                     }

--- a/ios/Fabric/VisionCameraViewComponentView.mm
+++ b/ios/Fabric/VisionCameraViewComponentView.mm
@@ -296,8 +296,8 @@ using namespace facebook::react;
 
   if (commandId != nil) {
     // Map command IDs to command names based on the order in supportedCommands array
-    // From VisionCameraViewNativeComponent.ts: ['capture', 'stop', 'start', 'toggleFlash', 'setZoom', 'setFocusSettings']
-    NSArray *commandNames = @[@"capture", @"stop", @"start", @"toggleFlash", @"setZoom", @"setFocusSettings"];
+    // From VisionCameraViewNativeComponent.ts: ['capture', 'stop', 'start', 'rescan', 'toggleFlash', 'setZoom', 'setFocusSettings']
+    NSArray *commandNames = @[@"capture", @"stop", @"start", @"rescan", @"toggleFlash", @"setZoom", @"setFocusSettings"];
 
     NSInteger cmdId = [commandId integerValue];
     if (cmdId >= 0 && cmdId < commandNames.count) {
@@ -327,6 +327,13 @@ using namespace facebook::react;
 {
   if ([_visionCameraView respondsToSelector:@selector(start)]) {
     [_visionCameraView performSelector:@selector(start)];
+  }
+}
+
+- (void)rescan
+{
+  if ([_visionCameraView respondsToSelector:@selector(rescan)]) {
+    [_visionCameraView performSelector:@selector(rescan)];
   }
 }
 

--- a/ios/RNVisionCameraView.swift
+++ b/ios/RNVisionCameraView.swift
@@ -762,6 +762,15 @@ extension RNVisionCameraView: CodeScannerViewDelegate {
         "width": code.boundingBox.size.width,
         "height": code.boundingBox.size.height
       ]
+      // 0–1 normalized rect in image coordinates, top-left origin.
+      // Use this when overlaying on the captured image — it survives
+      // aspect-ratio differences between preview and saved photo.
+      codeInfo["normalizedBoundingBox"] = [
+        "x": code.normalizedBoundingBox.origin.x,
+        "y": code.normalizedBoundingBox.origin.y,
+        "width": code.normalizedBoundingBox.size.width,
+        "height": code.normalizedBoundingBox.size.height
+      ]
       if let gs1Info = code.extractedData {
         codeInfo["gs1ExtractedInfo"] = gs1Info
       }
@@ -814,16 +823,18 @@ extension RNVisionCameraView: CodeScannerViewDelegate {
         "scannedCode": code.stringValue,
         "symbology": code.symbology.stringValue(),
         "gs1ExtractedInfo": code.extractedData ?? [:],
-        "boundingBox": dict(from: code.boundingBox)
+        "boundingBox": dict(from: code.boundingBox),
+        "normalizedBoundingBox": dict(from: code.normalizedBoundingBox)
       ]
     }
-    
+
     let qrCodeBoundingBoxes = qrCode.map { code in
       return [
         "scannedCode": code.stringValue,
         "symbology": code.symbology.stringValue(),
         "gs1ExtractedInfo": code.extractedData ?? [:],
-        "boundingBox": dict(from: code.boundingBox)
+        "boundingBox": dict(from: code.boundingBox),
+        "normalizedBoundingBox": dict(from: code.normalizedBoundingBox)
       ]
     }
     
@@ -871,7 +882,8 @@ extension RNVisionCameraView: CodeScannerViewDelegate {
             "scannedCode": barcode.stringValue,
             "symbology": barcode.symbology.stringValue(),
             "gs1ExtractedInfo": barcode.extractedData ?? [:],
-            "boundingBox": dict(from: barcode.boundingBox)
+            "boundingBox": dict(from: barcode.boundingBox),
+            "normalizedBoundingBox": dict(from: barcode.normalizedBoundingBox)
           ]
         }
       ])

--- a/ios/RNVisionCameraView.swift
+++ b/ios/RNVisionCameraView.swift
@@ -392,7 +392,16 @@ class RNVisionCameraView: UIView {
   @objc func capture() {
     cameraView?.capturePhoto()
   }
-  
+
+  /// Tear down the camera + analyzer + overlay and rebuild from scratch.
+  /// Exposed for parity with Android, where it's required for repeated captures
+  /// (the Android SDK's stopScanning() runs inside onCaptureSuccess and leaves
+  /// isScanning=false until rescan resets it). On iOS this just delegates to
+  /// the existing internal cameraView.rescan() — safe to call after each capture.
+  @objc func rescan() {
+    cameraView?.rescan()
+  }
+
   @objc func toggleFlash(enabled: Bool) {
     self.enableFlash = enabled
     updateFlash()

--- a/ios/VisionSdkModule.swift
+++ b/ios/VisionSdkModule.swift
@@ -932,7 +932,19 @@ class VisionSdkModule: RCTEventEmitter {
           finalRect = CGRect(x: x, y: y, width: width, height: height)
         }
 
-        return DetectedCode(stringValue: stringValue, symbology: symbology, extractedData: extractedData, boundingBox: finalRect)
+        // Read "normalizedBoundingBox" (0–1 normalized, top-left origin) so the OCR
+        // pipeline can crop the captured image around each barcode without depending
+        // on preview-pixel coords. Falls back to .zero for older consumers.
+        var normalizedRect: CGRect = .zero
+        if let normRect = barcodeDict["normalizedBoundingBox"] as? [String: CGFloat] {
+          let nx: CGFloat = normRect["x"] ?? 0
+          let ny: CGFloat = normRect["y"] ?? 0
+          let nw: CGFloat = normRect["width"] ?? 0
+          let nh: CGFloat = normRect["height"] ?? 0
+          normalizedRect = CGRect(x: nx, y: ny, width: nw, height: nh)
+        }
+
+        return DetectedCode(stringValue: stringValue, symbology: symbology, extractedData: extractedData, boundingBox: finalRect, normalizedBoundingBox: normalizedRect)
       }
 
       // Call extractDataFromImageUsing with explicit modelClass and modelSize

--- a/src/VisionCamera.tsx
+++ b/src/VisionCamera.tsx
@@ -88,6 +88,20 @@ const Camera = forwardRef<VisionCameraRefProps, VisionCameraProps>(
         }
       },
 
+      // Tear down the camera + analyzer + overlay and rebuild from scratch.
+      // Required after a successful capture (or on Android-specific lifecycle
+      // recovery) because the native SDK calls stopScanning() inside its
+      // onCaptureSuccess handler, which leaves isScanning=false. Subsequent
+      // capture() calls bail out with CallStartCameraOrRescanBeforeCapture.
+      // Auto-rescan was disabled in v3.0.x to fix overlay flicker, so consumers
+      // must invoke this imperatively after each capture for repeated captures
+      // to work.
+      rescan: () => {
+        if (VisionCameraViewRef.current) {
+          Commands.rescan(VisionCameraViewRef.current);
+        }
+      },
+
       toggleFlash: (enabled: boolean) => {
         if (VisionCameraViewRef.current) {
           Commands.toggleFlash(VisionCameraViewRef.current, enabled);

--- a/src/VisionCameraTypes.ts
+++ b/src/VisionCameraTypes.ts
@@ -123,9 +123,15 @@ export interface VisionCameraBarcodeResult {
 
   /**
    * @type {object}
-   * @description Bounding box coordinates of the detected barcode in preview-pixel
-   * space (the camera view's bounds). Use this for overlays drawn on top of the
-   * live preview.
+   * @description Bounding box of the detected barcode in the camera view's
+   * coordinate space. Units vary by event source:
+   * - iOS (all events): UIView points (RN layout units).
+   * - Android `onBoundingBoxesUpdate`: DP (RN layout units, matches iOS).
+   * - Android `onBarcodeDetected` / `onCapture`: preview-view pixels.
+   *
+   * For overlays on the live preview, use `onBoundingBoxesUpdate` and treat
+   * values as RN layout units on both platforms. For overlays on the captured
+   * image, prefer `normalizedBoundingBox` and multiply by image width/height.
    */
   boundingBox: {
     x: number;
@@ -301,7 +307,11 @@ export interface VisionCameraDetectedCodeBoundingBox {
 
   /**
    * @type {VisionCameraBoundingBox}
-   * @description Bounding box coordinates of the detected code in preview-pixel space.
+   * @description Bounding box of the detected code in the camera view's
+   * coordinate space. iOS sends points; Android `onBoundingBoxesUpdate` sends
+   * DP (so RN absolute-positioned overlays work on both platforms). Other
+   * Android events send preview-view pixels — prefer `normalizedBoundingBox`
+   * for cross-platform image overlays.
    */
   boundingBox: VisionCameraBoundingBox;
 
@@ -625,11 +635,13 @@ export interface VisionCameraRefProps {
 
   /**
    * Tears down the camera session and rebuilds it from scratch.
-   * @description Required for repeated captures: the native SDK calls stopScanning()
-   * inside its onCaptureSuccess handler, which leaves isScanning=false. Subsequent
-   * capture() calls bail out with CallStartCameraOrRescanBeforeCapture. Auto-rescan
-   * was disabled in v3.0.x to fix overlay flicker, so consumers must call this after
-   * each successful capture for the next capture to work.
+   * @description Required on Android for repeated captures: the Android SDK calls
+   * stopScanning() inside its onCaptureSuccess handler, which leaves isScanning=false.
+   * Subsequent capture() calls bail out with CallStartCameraOrRescanBeforeCapture
+   * (auto-rescan-after-capture was disabled in v3.0.x to fix overlay flicker). On
+   * iOS the SDK auto-rescans internally after capture/detection, so calling
+   * rescan() there is a no-op-equivalent — safe but redundant. Calling on both
+   * platforms is safe and recommended for cross-platform consumers.
    */
   rescan: () => void;
 

--- a/src/VisionCameraTypes.ts
+++ b/src/VisionCameraTypes.ts
@@ -601,6 +601,16 @@ export interface VisionCameraRefProps {
   start: () => void;
 
   /**
+   * Tears down the camera session and rebuilds it from scratch.
+   * @description Required for repeated captures: the native SDK calls stopScanning()
+   * inside its onCaptureSuccess handler, which leaves isScanning=false. Subsequent
+   * capture() calls bail out with CallStartCameraOrRescanBeforeCapture. Auto-rescan
+   * was disabled in v3.0.x to fix overlay flicker, so consumers must call this after
+   * each successful capture for the next capture to work.
+   */
+  rescan: () => void;
+
+  /**
    * Toggles the flash mode.
    * @param {boolean} enabled - Whether flash should be enabled.
    */

--- a/src/VisionCameraTypes.ts
+++ b/src/VisionCameraTypes.ts
@@ -123,9 +123,25 @@ export interface VisionCameraBarcodeResult {
 
   /**
    * @type {object}
-   * @description Bounding box coordinates of the detected barcode.
+   * @description Bounding box coordinates of the detected barcode in preview-pixel
+   * space (the camera view's bounds). Use this for overlays drawn on top of the
+   * live preview.
    */
   boundingBox: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+
+  /**
+   * @type {object}
+   * @description Bounding box normalized to 0–1 in image coordinates with top-left
+   * origin. Use this when overlaying on the captured image (the saved photo) —
+   * it survives any aspect-ratio difference between the preview and the image.
+   * Multiply by image width/height to get pixel coordinates.
+   */
+  normalizedBoundingBox?: {
     x: number;
     y: number;
     width: number;
@@ -285,9 +301,16 @@ export interface VisionCameraDetectedCodeBoundingBox {
 
   /**
    * @type {VisionCameraBoundingBox}
-   * @description Bounding box coordinates of the detected code.
+   * @description Bounding box coordinates of the detected code in preview-pixel space.
    */
   boundingBox: VisionCameraBoundingBox;
+
+  /**
+   * @type {VisionCameraBoundingBox}
+   * @description Bounding box normalized to 0–1 in image coordinates with top-left
+   * origin. Multiply by image width/height to overlay on the captured image.
+   */
+  normalizedBoundingBox?: VisionCameraBoundingBox;
 }
 
 /**

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -16,6 +16,7 @@ jest.mock('../specs/VisionCameraViewNativeComponent', () => {
       capture: jest.fn(),
       stop: jest.fn(),
       start: jest.fn(),
+      rescan: jest.fn(),
       toggleFlash: jest.fn(),
       setZoom: jest.fn(),
       setFocusSettings: jest.fn(),
@@ -176,6 +177,18 @@ describe('VisionCamera', () => {
         expect.anything(),
         JSON.stringify(settings)
       );
+    });
+
+    it('rescan dispatches Commands.rescan with the view ref', () => {
+      const ref = React.createRef<any>();
+      renderInAct(<VisionCamera ref={ref} />);
+
+      act(() => {
+        ref.current.rescan();
+      });
+
+      expect(Commands.rescan).toHaveBeenCalledTimes(1);
+      expect(Commands.rescan).toHaveBeenCalledWith(expect.anything());
     });
   });
 });

--- a/src/specs/VisionCameraViewNativeComponent.ts
+++ b/src/specs/VisionCameraViewNativeComponent.ts
@@ -83,13 +83,14 @@ interface NativeCommands {
   capture: (viewRef: React.ElementRef<HostComponent<NativeProps>>) => void;
   stop: (viewRef: React.ElementRef<HostComponent<NativeProps>>) => void;
   start: (viewRef: React.ElementRef<HostComponent<NativeProps>>) => void;
+  rescan: (viewRef: React.ElementRef<HostComponent<NativeProps>>) => void;
   toggleFlash: (viewRef: React.ElementRef<HostComponent<NativeProps>>, enabled: boolean) => void;
   setZoom: (viewRef: React.ElementRef<HostComponent<NativeProps>>, level: Float) => void;
   setFocusSettings: (viewRef: React.ElementRef<HostComponent<NativeProps>>, settingsJson: string) => void;
 }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ['capture', 'stop', 'start', 'toggleFlash', 'setZoom', 'setFocusSettings'],
+  supportedCommands: ['capture', 'stop', 'start', 'rescan', 'toggleFlash', 'setZoom', 'setFocusSettings'],
 });
 
 export default codegenNativeComponent<NativeProps>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -237,7 +237,8 @@ export interface BarcodeResult {
   scannedCode: string; // The scanned barcode value
   symbology?: string; // Barcode symbology type (e.g., QR, EAN, CODE128)
   gs1ExtractedInfo?: Record<string, string>; // Additional extracted information as a key-value map
-  boundingBox?: BoundingBox; // Bounding box coordinates of the detected barcode
+  boundingBox?: BoundingBox; // Bounding box in preview-pixel space (camera view bounds)
+  normalizedBoundingBox?: BoundingBox; // 0–1 normalized rect in image coordinates, top-left origin — multiply by image width/height to overlay on the captured image
 }
 
 /**
@@ -284,7 +285,15 @@ export interface DetectedCodeBoundingBox {
   scannedCode: string;
   symbology: string;
   gs1ExtractedInfo?: Record<string, string>;
+  /** Bounding box in preview-pixel space (camera view bounds). */
   boundingBox: BoundingBox;
+  /**
+   * 0–1 normalized rect in image coordinates with top-left origin.
+   * Multiply by image width/height to overlay on the captured image —
+   * use this when overlay coordinates need to survive aspect-ratio
+   * differences between the preview and the saved photo.
+   */
+  normalizedBoundingBox?: BoundingBox;
 }
 
 export interface BoundingBoxesDetectedResult {
@@ -569,9 +578,15 @@ export interface DetectedBarcode {
   gs1ExtractedInfo?: Record<string, string>;
 
   /**
-   * Bounding box coordinates (optional)
+   * Bounding box in preview-pixel space (optional).
    */
   boundingBox?: BoundingBox;
+
+  /**
+   * 0–1 normalized rect in image coordinates with top-left origin (optional).
+   * Multiply by image width/height to overlay on the captured image.
+   */
+  normalizedBoundingBox?: BoundingBox;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -237,8 +237,20 @@ export interface BarcodeResult {
   scannedCode: string; // The scanned barcode value
   symbology?: string; // Barcode symbology type (e.g., QR, EAN, CODE128)
   gs1ExtractedInfo?: Record<string, string>; // Additional extracted information as a key-value map
-  boundingBox?: BoundingBox; // Bounding box in preview-pixel space (camera view bounds)
-  normalizedBoundingBox?: BoundingBox; // 0–1 normalized rect in image coordinates, top-left origin — multiply by image width/height to overlay on the captured image
+  /**
+   * Bounding box in the camera view's coordinate space. Units differ by event:
+   * iOS sends points (RN layout units); Android `onBoundingBoxesUpdate` sends DP
+   * (also RN layout units); Android `onBarcodeDetected` and `onCapture` send raw
+   * preview-view pixels. Prefer `normalizedBoundingBox` when overlaying on the
+   * captured image.
+   */
+  boundingBox?: BoundingBox;
+  /**
+   * 0–1 normalized rect in image coordinates with top-left origin.
+   * Multiply by image width/height to overlay on the captured image — works
+   * cross-platform regardless of preview/image aspect-ratio differences.
+   */
+  normalizedBoundingBox?: BoundingBox;
 }
 
 /**
@@ -285,13 +297,16 @@ export interface DetectedCodeBoundingBox {
   scannedCode: string;
   symbology: string;
   gs1ExtractedInfo?: Record<string, string>;
-  /** Bounding box in preview-pixel space (camera view bounds). */
+  /**
+   * Bounding box in the camera view's coordinate space. iOS: points.
+   * Android `onBoundingBoxesUpdate`: DP. Both are RN layout units, so values
+   * can be passed directly to absolute-positioned `<View>` styles.
+   */
   boundingBox: BoundingBox;
   /**
    * 0–1 normalized rect in image coordinates with top-left origin.
-   * Multiply by image width/height to overlay on the captured image —
-   * use this when overlay coordinates need to survive aspect-ratio
-   * differences between the preview and the saved photo.
+   * Multiply by image width/height to overlay on the captured image — use
+   * this whenever the preview aspect ratio may differ from the saved photo.
    */
   normalizedBoundingBox?: BoundingBox;
 }


### PR DESCRIPTION
## Summary

Fixes the multi-capture regression introduced in 3.0.7 (Android) and surfaces the SDK's `normalizedBoundingBox` end-to-end so consumers can overlay barcodes on the captured image without aspect-ratio math.

Bumps native Android dep `com.github.packagexlabs:vision-sdk-android` from `v2.4.42` → `v2.4.45` (already published to JitPack; carries the matching SDK-side fixes).

3 commits:
1. `30322af` — `rescan` command + `start()` guard + bump native dep to v2.4.45
2. `b178eb1` — forward `normalizedBoundingBox` in native → JS event payloads
3. `3aba206` — accept `normalizedBoundingBox` in JS → native `predictWithModule` dicts

## What's broken (multi-capture)

Since 3.0.7, `auto-rescan-after-capture` was disabled in the bridge to fix overlay flicker. But the native SDK's `onCaptureSuccess` calls `stopScanning()` internally, which sets `isScanning = false`. With auto-rescan removed and no JS-callable rescan, every subsequent `capture()` bailed out with `CallStartCameraOrRescanBeforeCapture` — JS just timed out at 5s.

Separately, the JS-side `useEffect` calling `Commands.start(ref)` after Fabric had already started the camera (via `onAfterUpdateTransaction`) caused `view.startCamera()` to run twice. The second pass tore down PreviewView's surface and rebuilt the `imageCaptureUseCase` field while CameraX's binding still pointed at the first one — the next `takePicture()` errored with **"Not bound to a valid Camera"**.

## What's fixed

**Bridge (`react-native-vision-sdk`):**
- `rescan` added to codegen native command spec, JS imperative ref (`VisionCameraRefProps.rescan: () => void`), Android Fabric ViewManager dispatch, iOS Swift method, and iOS Fabric component view dispatcher. Consumers call it after every successful capture to reset `isScanning`.
- `start` command no-ops when `view.isCameraStarted()` already returns true. Prevents the duplicate-bind that orphans `imageCaptureUseCase`.

**Native Android SDK** (paired fixes in `com.github.packagexlabs:vision-sdk-android:v2.4.45` — already on JitPack):
- `startScanning()` early-returns when `camera != null`.
- `rescan()` nulls `camera` + `isScanning = false` before re-entering `startScanning()` so the rebind passes the new guard.

iOS doesn't have the same lifecycle bug; `rescan` is exposed for API parity and just delegates to the existing internal `cameraView.rescan()`.

## What's added (`normalizedBoundingBox` end-to-end)

Both native SDKs already produce a `normalizedBoundingBox` (iOS `DetectedCode` since 2.1.4, Android `ScannedCodeResult` since v2.4.42) — a 0–1 normalized rect in image coordinates with top-left origin. The bridge dropped it on the floor; JS only saw `boundingBox`, which is in preview-pixel space and breaks when the preview aspect ratio doesn't match the captured image.

**Native → JS** (every emit site now includes `normalizedBoundingBox`):
- Android `VisionCameraViewManager.kt`: `onBarcodeDetected`, barcode + qr arrays in `onIndicationsBoundingBoxes`, `onCapture`.
- iOS `RNVisionCameraView.swift`: same 4 sites.

**JS → Native predict**:
- iOS `VisionSdkModule.swift:predictWithModule` parses `normalizedBoundingBox` from the JS dict and passes to `DetectedCode(..., normalizedBoundingBox:)`.
- Android `VisionSdkModule.kt:predictWithModule` parses to `RectF` and passes to `ScannedCodeResult(..., normalizedBoundingBox = ...)`.

So when `VisionCore.predictWithModule(module, imagePath, barcodes)` is called, the OCR pipeline gets image-space coordinates and can crop the captured image around each barcode correctly — no more relying on preview-pixel coords.

**TS types** updated on `BarcodeResult`, `DetectedCode`, `DetectedCodeBoundingBox`, `VisionCameraDetectedCodeBoundingBox`, and `DetectedBarcode` (the predict input shape) — all gain optional `normalizedBoundingBox?: BoundingBox`. Optional because pre-2.1.4 iOS / pre-v2.4.42 Android consumers won't have it; current pinned versions do.

## Backward compatibility

- `boundingBox` field unchanged — same value as before (preview-pixel space). Existing consumers reading `bbox.boundingBox.{x,y,width,height}` keep working identically.
- `normalizedBoundingBox` is additive and optional — consumers that don't reference it see zero behavior change.
- `rescan()` is a new public method — old code that doesn't call it is unaffected.
- `start()` no-op-when-started is a fix, not a behavior change for correctly-written consumers.

#