### PR TITLE
ci: auto-publish to npm on PR merge + conventional-commit bumps

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,6 +6,10 @@ runs:
   steps:
     - name: Setup Node.js
       uses: actions/setup-node@v4
+      with:
+        # Writes ~/.npmrc with `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`
+        # so any `npm publish` in the workflow picks up the token from env.
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Install Yarn
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+# Fires on every push to `main` (which is what PR merges create, regardless of
+# whether you squash, rebase, or merge-commit), and on manual workflow_dispatch.
+# Loop guard further down skips the release commit release-it itself creates.
 on:
   push:
     branches:
@@ -8,11 +11,11 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: "Release type"
-        required: true
-        default: "patch"
+        description: "Release type (leave empty to use conventional commits)"
+        required: false
         type: choice
         options:
+          - ""
           - patch
           - minor
           - major
@@ -44,7 +47,18 @@ jobs:
       - name: Build package
         run: yarn prepare
 
+      # When `release_type` is set (manual dispatch), use it. Otherwise let
+      # release-it's conventional-changelog plugin pick the bump from commit
+      # messages — `feat:` → minor, `fix:` → patch, `BREAKING CHANGE:` → major.
+      # Hardcoding `patch` previously masked `feat:` commits that should have
+      # been minor releases.
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: yarn release ${{ inputs.release_type || 'patch' }} --ci --npm.provenance
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -n "${{ inputs.release_type }}" ]; then
+            yarn release "${{ inputs.release_type }}" --ci --npm.provenance
+          else
+            yarn release --ci --npm.provenance
+          fi


### PR DESCRIPTION
## Summary

The Release workflow already triggers on every push to `main` (which is what PR merges create — squash/rebase/merge-commit all produce a push event), but two things kept it from actually publishing:

### 1. No npm auth — yesterday's `ENEEDAUTH`

`actions/setup-node@v4` was invoked without `registry-url`, so `.npmrc` was never wired for token auth, and the Release step had no `NODE_AUTH_TOKEN`. Yesterday's release run got all the way through `bob build` + tarball prep, then failed at `npm publish` with:

```
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
```

release-it rolled back, so `package.json` is still at `3.0.9` and tag `v3.0.10` was never pushed — the slot is free.

Fix: pass `registry-url: 'https://registry.npmjs.org'` to `setup-node` (writes `.npmrc` with `:_authToken=${NODE_AUTH_TOKEN}`) and plumb `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` into the Release step's env.

### 2. Hardcoded `patch` bump

`yarn release patch …` ran even when commits carried `feat:` prefixes. The conventional-changelog plugin warned `recommended bump is "minor", but is overridden with "patch"` in the prior CI log. Hardcoded patch bumps mask real minor releases.

Fix: when no explicit type is passed via `workflow_dispatch`, run `yarn release` with no bump arg and let `@release-it/conventional-changelog` pick. `feat:` → minor, `fix:` → patch, `BREAKING CHANGE:` → major. Manual `workflow_dispatch` retains the override via the `release_type` input (now optional, default empty).

## Required repo setup (one-time)

This PR cannot publish until **`NPM_TOKEN`** is added to repo secrets:

1. Create at <https://www.npmjs.com/settings/{your-username}/tokens> → "Generate New Token" → **Automation** type (bypasses 2FA).
2. Add at <https://github.com/packagex-io/react-native-vision-sdk/settings/secrets/actions/new> → name `NPM_TOKEN`, paste the `npm_…` value.

`GITHUB_TOKEN` and OIDC `id-token` (for provenance) are auto-provided by GitHub per workflow run — no setup needed.

## After this merges

Every PR merge to `main` will:
- Trigger `.github/workflows/release.yml`
- Pick bump type from conventional commits
- Auth to npmjs.com via `NODE_AUTH_TOKEN`
- Publish with provenance attestation

The loop-guard (`if: !startsWith('chore: release')`) still skips release-it's own version-bump commit so we don't recurse.

## Test plan

- [ ] Add `NPM_TOKEN` repo secret per the steps above
- [ ] Merge this PR
- [ ] Confirm the workflow runs, picks the right bump from the commits since `v3.0.9`, publishes `react-native-vision-sdk` to npm, pushes the `v3.0.10` (or whatever conventional commits resolve to) tag, and creates the GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
