### PR TITLE
ci: upgrade npm before release to enable trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Build package
         run: yarn prepare
 


### PR DESCRIPTION
npm trusted publishing (OIDC) requires npm >= 11.5.1, but setup-node@v5 defaults to a Node LTS that still ships with npm 10.x. Without the upgrade, npm skips the OIDC exchange and publishes anonymously, which the registry rejects as 404.