### PR TITLE
ci: use sudo when upgrading npm globally

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: sudo npm install -g npm@latest
 
       - name: Build package
         run: yarn prepare


### PR DESCRIPTION
The ubuntu-latest runner's Node lives under /usr/local, which is root-owned, so `npm install -g` without sudo fails with EACCES on /usr/local/share/man.