### PR TITLE
ci: sudo the npm-latest upgrade so it can write to /usr/local

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,8 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        # /usr/local on ubuntu-latest is root-owned, so npm -g needs sudo.
+        run: sudo npm install -g npm@latest
 
       - name: Build package
         run: yarn prepare


### PR DESCRIPTION
Fix for the EACCES in the latest Release run (`/usr/local/share/man/man7`). On `ubuntu-latest`, `npm install -g` writes manpages and binlinks under `/usr/local` which is root-owned — needs `sudo`. One-line diff.