### PR TITLE
feat: iOS dimensioning bridge (VisionSDK 2.3.0) + security/deps housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,11 @@ buck-out/
 android/app/libs
 android/keystores/debug.keystore
 
+# Environment / secrets
+.env
+.env.*
+!.env.example
+
 # Expo
 .expo/
 

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,10 @@ example/.yarn/*
 BACKLOG.md
 .local
 package-lock.json
+
+# Local Claude config and node-path file (machine-specific)
+.claude/
+**/.xcode.env
+
+# npm pack output
+*.tgz

--- a/README.md
+++ b/README.md
@@ -953,7 +953,7 @@ target 'YourApp' do
 end
 ```
 
-The Dimensioning subspec is pulled in automatically by `react-native-vision-sdk` when you import `DimensioningView` or `VisionDimensioning`. Make sure your iOS deployment target is **17.0 or higher** — the Dimensioning subspec brings ARKit, RealityKit, and the LiDAR runtime which all require iOS 17.
+The `react-native-vision-sdk` podspec depends on `VisionSDK/Core` and `VisionSDK/Dimensioning` directly, so installing the npm package via `pod install` always pulls in both subspecs and links MVDimensioningCore / ARKit / RealityKit. Make sure your iOS deployment target is **17.0 or higher** — the Dimensioning subspec requires it.
 
 Add the following keys to your `Info.plist`:
 
@@ -1007,12 +1007,12 @@ function MyScreen() {
       measurementUnit="centimeters"   // any Foundation.UnitLength symbol
       maximumTrackCount={5}
       onCapture={(m: DimensioningMeasurement) => {
-        console.log(m.length, m.width, m.height);
-        console.log(m.confidence, m.volume);
+        console.log(m.length, m.lengthUnit, m.width, m.widthUnit, m.height, m.heightUnit);
+        console.log('confidence:', m.confidence);
       }}
       onError={(e: DimensioningError) => {
         // e.code: numeric DimensioningErrorCode
-        // e.domain, e.message, optional e.reason
+        // e.message, optional e.reason
         console.warn(e.message);
       }}
     />
@@ -1025,7 +1025,7 @@ function MyScreen() {
 | Prop | Type | Default | Notes |
 |---|---|---|---|
 | `mode` | `'offline'` \| `'online'` | `'offline'` | `.offline` runs entirely on-device. `.online` augments the pipeline with a cloud-side step (requires `VSDKConstants.apiKey`). |
-| `measurementUnit` | string | `'centimeters'` | Any `Foundation.UnitLength` symbol (`'inches'`, `'millimeters'`, ...). |
+| `measurementUnit` | string | `'centimeters'` | **Currently not honored** by the iOS native side — measurements always come back in centimeters (visible on the `lengthUnit` / `widthUnit` / `heightUnit` fields of each capture). Will be wired through `VSDKDimensioningConfiguration` in a follow-up. |
 | `maximumTrackCount` | number | `5` | Cap on simultaneously tracked boxes. |
 | `onCapture` | `(m) => void` | — | Fired when a stable measurement locks. |
 | `onError` | `(e) => void` | — | Fired for capture/runtime errors. |
@@ -1033,31 +1033,39 @@ function MyScreen() {
 
 ### Measurement shape
 
+The native side emits a flat object — each dimension has a numeric value plus a separate unit-symbol string.
+
 ```ts
 type DimensioningMeasurement = {
-  id: string;                   // UUID
-  timestamp: string;            // ISO8601
-  length: { value: number; unit: string };  // unit matches measurementUnit
-  width:  { value: number; unit: string };
-  height: { value: number; unit: string };
-  distanceFromCamera: { value: number; unit: 'm' };
-  confidence: number;           // 0...1
-  usedCloudSAM: boolean;        // true when .online cloud path ran
-  volume: { value: number; unit: 'm^3' };
+  id: string;                 // UUID
+  timestamp: number;          // Unix seconds
+  length: number;             // value in `lengthUnit` (currently always 'cm')
+  lengthUnit: string;
+  width: number;
+  widthUnit: string;
+  height: number;
+  heightUnit: string;
+  distanceFromCamera: number; // value in `distanceFromCameraUnit` (always 'm')
+  distanceFromCameraUnit: string;
+  confidence: number;         // 0...1
+  usedCloudSAM: boolean;      // true when .online cloud path ran
 };
 ```
 
 ### Error codes (`DimensioningErrorCode`)
 
-| Code | Constant | Trigger |
+The exported TS enum uses PascalCase member names; the table below shows both the runtime numeric value (which is what `error.code` will be) and the matching enum member.
+
+| Code | Enum member | Trigger |
 |---|---|---|
-| 0 | `MISSING_CREDENTIALS` | `.online` started without `VSDKConstants.apiKey` set |
-| 1 | `NOT_CONFIGURED` | Internal lifecycle error |
-| 2 | `LIDAR_UNAVAILABLE` | Non-LiDAR device or simulator |
-| 3 | `AR_SESSION_FAILED` | ARKit interruption; `e.reason` carries the underlying message |
-| 4 | `NO_GROUND_PLANE` | Could not anchor a horizontal surface |
-| 5 | `CAPTURE_TIMED_OUT` | `capture()` never reached a stable measurement |
-| 6 | `USER_CANCELLED` | Cancellation propagated from the session |
+| 0 | `MissingCredentials` | `.online` started without `VSDKConstants.apiKey` set |
+| 1 | `NotConfigured` | Internal lifecycle error |
+| 2 | `LidarUnavailable` | Non-LiDAR device or simulator |
+| 3 | `ArSessionFailed` | ARKit interruption; `e.reason` carries the underlying message |
+| 4 | `NoGroundPlane` | Could not anchor a horizontal surface |
+| 5 | `CaptureTimedOut` | `capture()` never reached a stable measurement |
+| 6 | `UserCancelled` | Cancellation propagated from the session |
+| 7 | `InternalError` | Bridge / serialization failure (not from `VSDKDimensioningError`) |
 
 ### Capture-session conflict with `<VisionCamera>`
 

--- a/README.md
+++ b/README.md
@@ -931,6 +931,151 @@ See the [Headless OCR Example](#headless-ocr-example) and [Model Management API]
 
 ---
 
+## Dimensioning (3D Box Measurement, iOS only)
+
+The `<DimensioningView>` component measures a real-world box's length, width, height, and volume using the device's LiDAR sensor.
+
+### Platform support
+
+- **iOS only.** Requires iOS 17.0+ on a LiDAR-equipped device (iPhone 12 Pro and newer, LiDAR-equipped iPads).
+- **Android**: not supported. `VisionDimensioning.deviceCapabilities()` resolves with all-false flags and the component renders a "not supported on this platform" placeholder.
+- **iOS Simulator**: no LiDAR; the component will return `lidarUnavailable` if you mount it.
+
+### iOS install
+
+The Dimensioning subspec is opt-in. In your app's `Podfile`:
+
+```ruby
+platform :ios, '17.0'
+
+target 'YourApp' do
+  use_react_native!(...)
+end
+```
+
+The Dimensioning subspec is pulled in automatically by `react-native-vision-sdk` when you import `DimensioningView` or `VisionDimensioning`. Make sure your iOS deployment target is **17.0 or higher** — the Dimensioning subspec brings ARKit, RealityKit, and the LiDAR runtime which all require iOS 17.
+
+Add the following keys to your `Info.plist`:
+
+```xml
+<key>NSCameraUsageDescription</key>
+<string>Required for box dimensioning</string>
+<key>Privacy - LiDAR Usage Description</key>
+<string>Required for 3D box measurement</string>
+```
+
+### App-launch setup (optional but recommended)
+
+Pre-warm the on-device models at app startup so the first session opens without a cold-start delay. This is a no-op on Android.
+
+```tsx
+import { VisionDimensioning } from 'react-native-vision-sdk';
+
+// In your root App component (componentDidMount / useEffect)
+VisionDimensioning.prefetchModels();
+```
+
+### Hardware capability check
+
+Always gate the dimensioning entry point on `deviceCapabilities()`:
+
+```tsx
+import { VisionDimensioning } from 'react-native-vision-sdk';
+
+const caps = await VisionDimensioning.deviceCapabilities();
+// { lidar: boolean, arWorldTracking: boolean, sceneReconstruction: boolean }
+
+if (!caps.lidar) {
+  // Hide the dimensioning UI on non-LiDAR devices
+}
+```
+
+### Component usage
+
+```tsx
+import {
+  DimensioningView,
+  type DimensioningMeasurement,
+  type DimensioningError,
+} from 'react-native-vision-sdk';
+
+function MyScreen() {
+  return (
+    <DimensioningView
+      style={{ flex: 1 }}
+      mode="offline"                  // 'offline' (default) | 'online'
+      measurementUnit="centimeters"   // any Foundation.UnitLength symbol
+      maximumTrackCount={5}
+      onCapture={(m: DimensioningMeasurement) => {
+        console.log(m.length, m.width, m.height);
+        console.log(m.confidence, m.volume);
+      }}
+      onError={(e: DimensioningError) => {
+        // e.code: numeric DimensioningErrorCode
+        // e.domain, e.message, optional e.reason
+        console.warn(e.message);
+      }}
+    />
+  );
+}
+```
+
+### Props
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `mode` | `'offline'` \| `'online'` | `'offline'` | `.offline` runs entirely on-device. `.online` augments the pipeline with a cloud-side step (requires `VSDKConstants.apiKey`). |
+| `measurementUnit` | string | `'centimeters'` | Any `Foundation.UnitLength` symbol (`'inches'`, `'millimeters'`, ...). |
+| `maximumTrackCount` | number | `5` | Cap on simultaneously tracked boxes. |
+| `onCapture` | `(m) => void` | — | Fired when a stable measurement locks. |
+| `onError` | `(e) => void` | — | Fired for capture/runtime errors. |
+| `style` | `ViewStyle` | — | Standard RN view style. |
+
+### Measurement shape
+
+```ts
+type DimensioningMeasurement = {
+  id: string;                   // UUID
+  timestamp: string;            // ISO8601
+  length: { value: number; unit: string };  // unit matches measurementUnit
+  width:  { value: number; unit: string };
+  height: { value: number; unit: string };
+  distanceFromCamera: { value: number; unit: 'm' };
+  confidence: number;           // 0...1
+  usedCloudSAM: boolean;        // true when .online cloud path ran
+  volume: { value: number; unit: 'm^3' };
+};
+```
+
+### Error codes (`DimensioningErrorCode`)
+
+| Code | Constant | Trigger |
+|---|---|---|
+| 0 | `MISSING_CREDENTIALS` | `.online` started without `VSDKConstants.apiKey` set |
+| 1 | `NOT_CONFIGURED` | Internal lifecycle error |
+| 2 | `LIDAR_UNAVAILABLE` | Non-LiDAR device or simulator |
+| 3 | `AR_SESSION_FAILED` | ARKit interruption; `e.reason` carries the underlying message |
+| 4 | `NO_GROUND_PLANE` | Could not anchor a horizontal surface |
+| 5 | `CAPTURE_TIMED_OUT` | `capture()` never reached a stable measurement |
+| 6 | `USER_CANCELLED` | Cancellation propagated from the session |
+
+### Capture-session conflict with `<VisionCamera>`
+
+Both the camera scanner and the dimensioning view own the rear camera. ARKit and `AVCaptureSession` cannot share it, so **mount only one at a time**. If you navigate between a scanner screen and a dimensioning screen, unmount the active one before showing the next.
+
+### Capture conditions for reliable results
+
+Typical variance is ±3-5 cm per dimension. To stay in that envelope:
+
+- Box on a flat horizontal surface, top face visible, whole box in frame.
+- Distance: 40-90 cm optimal (works between 30 cm and ~1.5 m).
+- Hold steady for 1-2 seconds during capture.
+- Cuboid shapes only — tubes, polybags, and soft bags are not supported.
+- Avoid highly reflective wrap, transparent film, very dark matte surfaces.
+- Ambient or diffuse warehouse lighting; avoid direct sun on glossy faces.
+
+---
+
 ## Platform-Specific Limitations & Differences
 
 While we strive to maintain feature parity across iOS and Android, certain limitations exist due to differences in the underlying native VisionSDK implementations.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -155,7 +155,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 // From node_modules
-  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.47'
+  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.48'
   implementation 'com.github.asadullahilyas:HandyUtils:1.1.6'
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,7 +76,9 @@ android {
 }
 
 repositories {
-  mavenLocal()
+  if (project.hasProperty('useMavenLocal')) {
+    mavenLocal()
+  }
   mavenCentral()
   google()
   maven { url = uri("https://jitpack.io") }

--- a/android/src/newarch/java/com/visionsdk/VisionSdkPackage.kt
+++ b/android/src/newarch/java/com/visionsdk/VisionSdkPackage.kt
@@ -4,6 +4,8 @@ import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ViewManager
+import com.visionsdk.dimensioning.DimensioningModule
+import com.visionsdk.dimensioning.DimensioningViewManager
 
 /**
  * New Architecture Package
@@ -14,12 +16,16 @@ import com.facebook.react.uimanager.ViewManager
 class VisionSdkPackage : ReactPackage {
   override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
     // TurboModules still need manual registration in Fabric
-    return listOf(VisionSdkModule(reactContext))
+    return listOf(
+      VisionSdkModule(reactContext),
+      DimensioningModule(reactContext),
+    )
   }
 
   override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
     return listOf(
-      VisionCameraViewManager(reactContext)
+      VisionCameraViewManager(reactContext),
+      DimensioningViewManager(reactContext),
     )
   }
 }

--- a/android/src/newarch/java/com/visionsdk/dimensioning/DimensioningModule.kt
+++ b/android/src/newarch/java/com/visionsdk/dimensioning/DimensioningModule.kt
@@ -1,0 +1,57 @@
+package com.visionsdk.dimensioning
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.module.annotations.ReactModule
+
+/**
+ * Android stub for the Dimensioning TurboModule.
+ *
+ * Android devices do not have LiDAR scanners, so:
+ * - [deviceCapabilities] always resolves with all capability flags `false`.
+ * - [prefetchModels] resolves immediately (no-op).
+ * - The DimensioningView renders a static "not supported" placeholder via
+ *   [DimensioningViewManager].
+ */
+@ReactModule(name = DimensioningModule.NAME)
+class DimensioningModule(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
+
+    companion object {
+        const val NAME = "DimensioningModule"
+    }
+
+    override fun getName(): String = NAME
+
+    /**
+     * Returns device capability flags for dimensioning.
+     * Android always returns `{ lidar: false, arWorldTracking: false, sceneReconstruction: false }`.
+     */
+    @ReactMethod
+    fun deviceCapabilities(promise: Promise) {
+        promise.resolve(
+            """{"lidar":false,"arWorldTracking":false,"sceneReconstruction":false}"""
+        )
+    }
+
+    /**
+     * Pre-warms dimensioning ML models. No-op on Android.
+     */
+    @ReactMethod
+    fun prefetchModels(promise: Promise) {
+        promise.resolve(null)
+    }
+
+    // Required by RN event emitter protocol even though no events are emitted.
+    @ReactMethod
+    fun addListener(eventName: String) {
+        // no-op
+    }
+
+    @ReactMethod
+    fun removeListeners(count: Double) {
+        // no-op
+    }
+}

--- a/android/src/newarch/java/com/visionsdk/dimensioning/DimensioningViewManager.kt
+++ b/android/src/newarch/java/com/visionsdk/dimensioning/DimensioningViewManager.kt
@@ -1,0 +1,54 @@
+package com.visionsdk.dimensioning
+
+import android.content.Context
+import android.graphics.Color
+import android.util.TypedValue
+import android.view.Gravity
+import android.widget.TextView
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.SimpleViewManager
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.annotations.ReactProp
+
+/**
+ * Android ViewManager for `DimensioningView`.
+ *
+ * Since Android has no LiDAR, this manager renders a static [TextView]
+ * explaining that the feature is iOS-only. No events are emitted.
+ */
+@ReactModule(name = DimensioningViewManager.REACT_CLASS)
+class DimensioningViewManager(
+    private val appContext: ReactApplicationContext,
+) : SimpleViewManager<TextView>() {
+
+    companion object {
+        const val REACT_CLASS = "DimensioningView"
+    }
+
+    override fun getName(): String = REACT_CLASS
+
+    override fun createViewInstance(context: ThemedReactContext): TextView {
+        val tv = TextView(context)
+        tv.text = "Dimensioning is not supported on Android. LiDAR is required (iOS only)."
+        tv.setTextColor(Color.parseColor("#666666"))
+        tv.setBackgroundColor(Color.parseColor("#F0F0F0"))
+        tv.gravity = Gravity.CENTER
+        tv.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
+        tv.setPadding(16.dp(context), 16.dp(context), 16.dp(context), 16.dp(context))
+        return tv
+    }
+
+    // Accept but ignore all props — the view is a static placeholder.
+    @ReactProp(name = "mode")
+    fun setMode(view: TextView, mode: String?) { /* no-op */ }
+
+    @ReactProp(name = "measurementUnit")
+    fun setMeasurementUnit(view: TextView, unit: String?) { /* no-op */ }
+
+    @ReactProp(name = "maximumTrackCount", defaultInt = 5)
+    fun setMaximumTrackCount(view: TextView, count: Int) { /* no-op */ }
+
+    private fun Int.dp(ctx: Context): Int =
+        (this * ctx.resources.displayMetrics.density).toInt()
+}

--- a/example/.env.example
+++ b/example/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env and fill in your values.
+# Never commit .env to source control.
+
+# PackageX API key — required for cloud OCR and model download in the example app.
+# Obtain from https://app.packagex.io/settings/developers
+PACKAGEX_API_KEY=your_packagex_api_key_here

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -8,5 +8,5 @@ ruby '2.7.5'
 # Cocoapods 1.15 introduced a bug which break the build. We will remove the upper
 # bound in the template on Cocoapods with next React Native release.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
-gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
+gem 'activesupport', '>= 7.2.3.1'
 gem 'xcodeproj', '< 1.26.0'

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -14,7 +14,7 @@ require_relative '../node_modules/react-native/scripts/react_native_pods'
  node_require('react-native/scripts/react_native_pods.rb')
  node_require('react-native-permissions/scripts/setup.rb')
 
-platform :ios, '16'
+platform :ios, '17'
 install! 'cocoapods', :deterministic_uuids => false
 
 setup_permissions([
@@ -77,5 +77,26 @@ target 'VisionSdkExample' do
       :mac_catalyst_enabled => false,
       # :ccache_enabled => true
     )
+
+    # Workarounds for Xcode 26 + RN 0.82 / fmt 11.0.2 compatibility:
+    # - Xcode 26 defaults `_LIBCPP_HARDENING_MODE=DEBUG` which makes some
+    #   std::string_view ops non-constexpr.
+    # - fmt 11.0.2's `FMT_STRING` uses `consteval` lambdas that fail to
+    #   compile-time-evaluate against the Xcode 26 libc++. Defining
+    #   FMT_USE_CONSTEVAL=0 falls back to the non-consteval code path.
+    # `-U` first so targets that build with `-Werror=macro-redefined`
+    # (Yoga, RCT-Folly, ...) don't fail on the redefinition.
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings['OTHER_CPLUSPLUSFLAGS'] ||= ['$(inherited)']
+        unless config.build_settings['OTHER_CPLUSPLUSFLAGS'].to_s.include?('FMT_USE_CONSTEVAL')
+          config.build_settings['OTHER_CPLUSPLUSFLAGS'] = Array(config.build_settings['OTHER_CPLUSPLUSFLAGS']) + [
+            '-U_LIBCPP_HARDENING_MODE',
+            '-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE',
+            '-DFMT_USE_CONSTEVAL=0',
+          ]
+        end
+      end
+    end
   end
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,6 +8,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
+  - PostHog (3.58.3)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -1869,7 +1870,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-vision-sdk (3.0.7):
+  - react-native-vision-sdk (3.0.10):
     - boost
     - DoubleConversion
     - fast_float
@@ -1896,7 +1897,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-    - VisionSDK (= 2.2.1)
+    - VisionSDK (= 2.3.0)
+    - VisionSDK/Dimensioning (= 2.3.0)
     - Yoga
   - React-NativeModulesApple (0.82.1):
     - boost
@@ -2847,7 +2849,12 @@ PODS:
     - SocketRocket
     - Yoga
   - SocketRocket (0.7.1)
-  - VisionSDK (2.2.1)
+  - VisionSDK (2.3.0):
+    - VisionSDK/Core (= 2.3.0)
+  - VisionSDK/Core (2.3.0)
+  - VisionSDK/Dimensioning (2.3.0):
+    - PostHog (~> 3.0)
+    - VisionSDK/Core
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2939,6 +2946,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - PostHog
     - SocketRocket
     - VisionSDK
 
@@ -3119,85 +3127,86 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  PostHog: f6da05611d29a8facb652f7e2ee8389bc3f96b67
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: f17e2ebc07876ca9ab8eb6e4b0a4e4647497ae3a
   RCTRequired: e2c574c1b45231f7efb0834936bd609d75072b63
   RCTTypeSafety: c693294e3993056955c3010eb1ebc574f1fcded6
   React: aeece948ccf155182ea86a2395786ed31cf21c61
   React-callinvoker: 05ad789505922d68c06cde1c8060e734df9fe182
-  React-Core: 956ac86b4d9b0c0fd9a14b9cc533aa297bb501c0
-  React-CoreModules: 3a8d39778cf9eeca40e419814e875da1a8e29855
-  React-cxxreact: db275765e1eb08f038599fb44114cf57ee0d18cd
+  React-Core: 727a48090292599bda380e05c9f1318e21578837
+  React-CoreModules: b26015efc6c222479e6939c0d7497cfac08a1a24
+  React-cxxreact: 1e6640d1e9a36744c4ce861bf2a5c8cee4abe9cf
   React-debug: 1dfa1d1cbd93bdaffa3b140190829f9fd9e27985
-  React-defaultsnativemodule: 35f353ba06901fb5e374bc56e750fde05cbb05b9
-  React-domnativemodule: cf9e1b1b520ce0e66396c2744b3eb6d419711c13
-  React-Fabric: c0b0c1ad70476d354b3da9fef96094f7b37804da
-  React-FabricComponents: 8c6861c5233cf0d5685cee301a979313090e2f57
-  React-FabricImage: cef8883d2fb6c892003fefcad261d2898adbe926
-  React-featureflags: 0e2b969019c2b118de64a6d4c55ef7c05f2b0f1d
-  React-featureflagsnativemodule: e1ef619d14fe0a68d4783b32293309dbb13ef2a5
-  React-graphics: 0fc6b7acaff7161bda05bf8bffceacc2b0b4e38d
-  React-hermes: b454b9352bc26e638704d103009f659a125b86d3
-  React-idlecallbacksnativemodule: 35ab292f8404c469744db5a5dd5f0f27f95e5ebf
-  React-ImageManager: 3312c550ebcf6b7d911d9993082adcb3e1407ce8
-  React-jserrorhandler: 2a7f2d94566f05f8cb82288afd46bc0fd8b2ffc7
-  React-jsi: 7aa265cf8372d8385ccc7935729e76d27e694dfe
-  React-jsiexecutor: 8dd53bebfb3bc12f0541282aa4c858a433914e37
-  React-jsinspector: f89b9ae62a4e2f6035b452442ef20a7f98f9cb27
-  React-jsinspectorcdp: 44e46c1473a8deecf7b188389ed409be83fb3cc7
-  React-jsinspectornetwork: dc9524f6e3d7694b1b6f4bd22dedad8ccc2c0a80
-  React-jsinspectortracing: 0166ebbdfb125936a5d231895de3c11a19521dfc
-  React-jsitooling: 34692514ec8d8735938eda3677808a58f41c925b
-  React-jsitracing: a598dae84a87f8013635d09c5e7884023bda8501
-  React-logger: 500f2fa5697d224e63c33d913c8a4765319e19bf
-  React-Mapbuffer: 06d59c448da7e34eb05b3fb2189e12f6a30fec57
-  React-microtasksnativemodule: d1ee999dc9052e23f6488b730fa2d383a4ea40e5
-  react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
-  react-native-vision-sdk: 6cda8b9bb9e32980f672b55e04962b5a5ce0bd28
-  React-NativeModulesApple: 46690a0fe94ec28fc6fc686ec797b911d251ded0
+  React-defaultsnativemodule: 5a7a0b2575032cd1ce8fac5d5e0611cf55d3bf2c
+  React-domnativemodule: 9e86dc9883b569f169e1e9da8c0e34292c469014
+  React-Fabric: bc78d9349f6385cb619e901911be752fb076730b
+  React-FabricComponents: 74412b4e4f29cfa8057edaf59fb3d7fc8d082b46
+  React-FabricImage: e5f1599f50d2c122c220744ed00ef1a271619938
+  React-featureflags: 773391abff0339af3697f8a987890191c122b320
+  React-featureflagsnativemodule: 4ffcace380a76af8982bdcf64ed29a02cea4fb75
+  React-graphics: 5d44b20c935d17bea4712edf5ce4834c4dead85d
+  React-hermes: 5c2453ae5a3c2f34a15eaefb229375998e365810
+  React-idlecallbacksnativemodule: e2b63f28f0b14a8ab01ba922b1611426b3999301
+  React-ImageManager: c50c501798a2bb89109db71ce74345bd9d6671d1
+  React-jserrorhandler: f773f1866064afd558506f9cd4cac19e6fcf9147
+  React-jsi: 389d2e9fe9bd935bdaff38e0d72eb2cad1ad3071
+  React-jsiexecutor: 0821fa7695e1a6a868aa47a40a0fc5036552128b
+  React-jsinspector: 9040cfa67dcaefbc856d8c79ab42e9be92736935
+  React-jsinspectorcdp: bf0403947b41a3fccab67cb11fd54f39a6d85351
+  React-jsinspectornetwork: f06ebe5a22316242b0f7b2b9514f03f3732306c5
+  React-jsinspectortracing: 6e22744e791cde5b4cd91343946dfa536f49f795
+  React-jsitooling: e9a0bab6a6ca8a0a5ee700d19e067bdb214eb5b5
+  React-jsitracing: af2ee8a89f5aa7495aae1f27edc422e00f5a6880
+  React-logger: fceaaedb9c715923a1900af68a7534e9b3a601a1
+  React-Mapbuffer: 7e7ca4c53288117e7e0406e9eaa804bf259b4b30
+  React-microtasksnativemodule: 885bebe5c5f25035e1fd0920776078840a0e3a76
+  react-native-safe-area-context: 54d812805f3c4e08a4580ad086cbde1d8780c2e4
+  react-native-vision-sdk: 8f0373bf5dae3df8574082b2ada438f40ee49143
+  React-NativeModulesApple: c4bee6aa736092cd347456488a4f97a8e7517604
   React-oscompat: 95875e81f5d4b3c7b2c888d5bd2c9d83450d8bdb
-  React-perflogger: 2e229bf33e42c094fd64516d89ec1187a2b79b5b
-  React-performancecdpmetrics: 05ba4bd83f36acf192071bb5d9c8f45faf04d140
-  React-performancetimeline: bfc96fcd2b79f7489dd54e3df4cba186dd8dd141
+  React-perflogger: d5b5677902d23a6611b700601634271b29356ac6
+  React-performancecdpmetrics: f20287f906b00a05070fce0bc400ea492991f13e
+  React-performancetimeline: c1f898134defda04623db379d57d9024d52ef63d
   React-RCTActionSheet: 2399bb6cc8adaef2e5850878102fea2ad1788a0e
-  React-RCTAnimation: d1deb6946e83e22a795a7d0148b94faad8851644
-  React-RCTAppDelegate: 10b35d5cec3f8653f6de843ae800b3ba8050b801
-  React-RCTBlob: 85150378edc42862d7c13ff2502693f32b174f91
-  React-RCTFabric: 736f9da3ad57e2cef5fa4c132999933a89bb8378
-  React-RCTFBReactNativeSpec: 705ec584758966950a31fa235539b57523059837
-  React-RCTImage: bb6cbdc22698b3afc8eb8d81ef03ee840d24c6f6
-  React-RCTLinking: e8b006d101c45651925de3e82189f03449eedfe7
-  React-RCTNetwork: 7999731af05ec8f591cbc6ad4e29d79e209c581a
-  React-RCTRuntime: 99d8a2a17747866fb972561cdb205afe9b26d369
-  React-RCTSettings: 839f334abb92e917bc24322036081ffe15c84086
-  React-RCTText: 272f60e9a5dbfd14c348c85881ee7d5c7749a67c
-  React-RCTVibration: 1ffa30a21e2227be3afe28d657ac8e6616c91bae
+  React-RCTAnimation: a7e596bacb4706501556dcaaa8cd4062c8858d40
+  React-RCTAppDelegate: 40a84753dc9d7c2535b9e748c30bae50d39c6580
+  React-RCTBlob: e3264ae55b1b856db8e654bb7066b8343e030a67
+  React-RCTFabric: e5bf005693c6edd581657979624bd33db479b008
+  React-RCTFBReactNativeSpec: 3984efab208a7d570cb2a5a8b94921ff61189307
+  React-RCTImage: fb1d64345bb2e26af63e06e1ffc2cf99d572e2e1
+  React-RCTLinking: cb91127e75ee2d081f1abffd08d63db185805439
+  React-RCTNetwork: f38a98b030faedf2dc5c9061d6ed0074b3513c72
+  React-RCTRuntime: fb2eb8fd62a7b9b3e8a29ad0ecf000b453070cb0
+  React-RCTSettings: 00cc62efb88ec24608cefaa7db4ad04461a511b4
+  React-RCTText: 2b963648a99f49875349bd18c0dd7f2a4acf50c1
+  React-RCTVibration: 16e31c7f90f13bec10385aeb5cc61e8a45e591e4
   React-rendererconsistency: 3c3e198aba0255524ed7126aa812d22ce750d217
-  React-renderercss: 6b3ce3dfadf991937ae3229112be843ef1438c32
-  React-rendererdebug: baf9e1daa07ac7f9aca379555126d29f963ba38b
-  React-RuntimeApple: 4136aee89257894955ef09e9f9ef74f0c27596be
-  React-RuntimeCore: e9a743d7de4bbd741b16e10b26078d815d6513ab
-  React-runtimeexecutor: 781e292362066af82fa2478d95c6b0e374421844
-  React-RuntimeHermes: 6ab3c2847516769fc860d711814f1735859cad74
-  React-runtimescheduler: 824c83a5fd68b35396de6d4f2f9ae995daac861b
-  React-timing: 1ebc7102dd52a3edcc63534686bb156e12648411
-  React-utils: abf37b162f560cd0e3e5d037af30bb796512246d
-  React-webperformancenativemodule: 50a57c713a90d27ae3ab947a6c9c8859bcb49709
-  ReactAppDependencyProvider: a45ef34bb22dc1c9b2ac1f74167d9a28af961176
-  ReactCodegen: 878add6c7d8ff8cea87697c44d29c03b79b6f2d9
-  ReactCommon: 804dc80944fa90b86800b43c871742ec005ca424
-  RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
-  RNGestureHandler: e1cf8ef3f11045536eed6bd4f132b003ef5f9a5f
-  RNPermissions: ce40243858e8ad423729adbdbb3e51b25e00552b
-  RNReanimated: ac06da53579693ab451941ef89f5a55afeab0dd9
-  RNScreens: d821082c6dd1cb397cc0c98b026eeafaa68be479
-  RNSVG: 005860704c95493cd23a417dfbeb76dcd8bb7042
-  RNVectorIcons: 791f13226ec4a3fd13062eda9e892159f0981fae
-  RNWorklets: ab618bf7d1c7fd2cb793b9f0f39c3e29274b3ebf
+  React-renderercss: d07e645ab9f2b411513c9d3947ad627a1ef3bec7
+  React-rendererdebug: 79ba04c9662222da80b140e75550e050c0520630
+  React-RuntimeApple: ab93dc2863d621b085788dc3781d141fd4d410f7
+  React-RuntimeCore: 301320b1d544ba82e8edb8c5e57f245cbc8bb2c0
+  React-runtimeexecutor: aa09562cd04c048b4246ef3997806df0ce0e7ff2
+  React-RuntimeHermes: e5b85c57ffd7d2913b4c85e96e133428ac6cb46d
+  React-runtimescheduler: 15a7e3d5b5d18d2e4def7c7cd937be2085fe9245
+  React-timing: 5d765a145ac47783de0bf116d4dd9cfa0c498819
+  React-utils: a9abebe9dc25642955b5d2cec8c16bbf55a1bc52
+  React-webperformancenativemodule: 85dce57a9e73457a3686aee0d8e929518713fc05
+  ReactAppDependencyProvider: cc2795efe30a023c3a505676b9c748b664b9c0a1
+  ReactCodegen: 897bad2d2f722ff4dc46fc144f9cc018db0e2ce4
+  ReactCommon: c5803af00bd3737dc1631749b1f1da5beba5b049
+  RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
+  RNGestureHandler: 927ba2c590c8973f24624f1c1279be08a22ec58d
+  RNPermissions: 5db71b5544a9c5ab2a5f121c2310b9e5269f0080
+  RNReanimated: fe6e74170e4b5c5acdbe10cf8f6883e410ba80d3
+  RNScreens: 3693ec4bbc0065151b843269e50e9807644e9918
+  RNSVG: 16667e18ce40770c8c41a87f3133004c5cf4e09a
+  RNVectorIcons: 6acc19c833be864e9c70894e101a587fe491150a
+  RNWorklets: daa0a3e7946a9c4042f3a962c87a12dc5bc0badd
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  VisionSDK: 3247867cdd77ff0004ed74fac07dc2f97e2d3110
+  VisionSDK: b09e1ca069b029244f16727921e54a9b445e2a21
   Yoga: 689c8e04277f3ad631e60fe2a08e41d411daf8eb
 
-PODFILE CHECKSUM: 283ed6c026f1bb62ac65d2aad8ca7784b733ccc7
+PODFILE CHECKSUM: 5b0f996e4be7dbc819fb164c540f2a83bf176cbf
 
 COCOAPODS: 1.16.2

--- a/example/ios/VisionSdkExample/PrivacyInfo.xcprivacy
+++ b/example/ios/VisionSdkExample/PrivacyInfo.xcprivacy
@@ -6,14 +6,6 @@
 	<array>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>C617.1</string>
-			</array>
-		</dict>
-		<dict>
-			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
@@ -22,10 +14,27 @@
 		</dict>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+				<string>3B52.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>35F9.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
 			</array>
 		</dict>
 	</array>

--- a/example/package.json
+++ b/example/package.json
@@ -29,8 +29,15 @@
   },
   "resolutions": {
     "@types/react": "^19.0.0",
-    "brace-expansion": "^1.1.12",
-    "on-headers": "1.1.0"
+    "brace-expansion": "^1.1.13",
+    "on-headers": "1.1.0",
+    "minimatch": "^3.1.5",
+    "babel-plugin-module-resolver/glob/minimatch": "^8.0.6",
+    "@typescript-eslint/typescript-estree/minimatch": "^9.0.7",
+    "picomatch": "^2.3.2",
+    "tinyglobby/picomatch": "^4.0.4",
+    "fast-xml-parser": "^4.5.5",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -4,6 +4,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import HomeScreen from './HomeScreen';
 import VisionCameraExample from './VisionCameraExample';
 import ModelManagementScreen from './ModelManagementScreen';
+import DimensioningScreen from './DimensioningScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -14,6 +15,7 @@ const App = () => {
         <Stack.Screen name="HomeScreen" component={HomeScreen} options={{ title: 'Vision SDK Home' }} />
         <Stack.Screen name="VisionCameraExample" component={VisionCameraExample} options={{ headerShown: false }} />
         <Stack.Screen name="ModelManagementScreen" component={ModelManagementScreen} options={{ title: 'Model Management API' }} />
+        <Stack.Screen name="DimensioningScreen" component={DimensioningScreen} options={{ title: 'Dimensioning (iOS)' }} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/example/src/DimensioningScreen.tsx
+++ b/example/src/DimensioningScreen.tsx
@@ -1,0 +1,159 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  Platform,
+  ActivityIndicator,
+} from 'react-native';
+import {
+  DimensioningView,
+  VisionDimensioning,
+  type DimensioningCapabilities,
+  type DimensioningMeasurement,
+  type DimensioningError,
+} from '../../src/dimensioning';
+
+const DimensioningScreen = () => {
+  const [capabilities, setCapabilities] = useState<DimensioningCapabilities | null>(null);
+  const [capError, setCapError] = useState<string | null>(null);
+  const [measurement, setMeasurement] = useState<DimensioningMeasurement | null>(null);
+  const [scanError, setScanError] = useState<DimensioningError | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (Platform.OS !== 'ios') {
+      setCapError('Dimensioning is iOS-only.');
+      setLoading(false);
+      return;
+    }
+
+    VisionDimensioning.deviceCapabilities()
+      .then((caps) => {
+        setCapabilities(caps);
+        setLoading(false);
+      })
+      .catch((err: Error) => {
+        setCapError(err.message);
+        setLoading(false);
+      });
+  }, []);
+
+  const handleCapture = (m: DimensioningMeasurement) => {
+    setMeasurement(m);
+    setScanError(null);
+  };
+
+  const handleError = (err: DimensioningError) => {
+    setScanError(err);
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" />
+        <Text style={styles.loadingText}>Checking capabilities…</Text>
+      </View>
+    );
+  }
+
+  if (capError || !capabilities) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.errorText}>{capError ?? 'Failed to get capabilities'}</Text>
+      </View>
+    );
+  }
+
+  if (!capabilities.lidar) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.errorText}>
+          This device does not have LiDAR. Dimensioning requires a Pro/Max iPhone with LiDAR.
+        </Text>
+        <Text style={styles.capText}>
+          lidar: {String(capabilities.lidar)}{'\n'}
+          arWorldTracking: {String(capabilities.arWorldTracking)}{'\n'}
+          sceneReconstruction: {String(capabilities.sceneReconstruction)}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <DimensioningView
+        style={styles.camera}
+        mode="offline"
+        measurementUnit="centimeters"
+        maximumTrackCount={5}
+        onCapture={handleCapture}
+        onError={handleError}
+      />
+
+      <ScrollView style={styles.resultsPanel}>
+        {scanError ? (
+          <View style={styles.errorBox}>
+            <Text style={styles.errorLabel}>Error ({scanError.code})</Text>
+            <Text style={styles.errorText}>{scanError.message}</Text>
+            {scanError.reason ? (
+              <Text style={styles.errorReason}>{scanError.reason}</Text>
+            ) : null}
+          </View>
+        ) : null}
+
+        {measurement ? (
+          <View style={styles.resultBox}>
+            <Text style={styles.resultTitle}>Last Measurement</Text>
+            <Text style={styles.resultText}>
+              L: {measurement.length.toFixed(1)} {measurement.lengthUnit}
+            </Text>
+            <Text style={styles.resultText}>
+              W: {measurement.width.toFixed(1)} {measurement.widthUnit}
+            </Text>
+            <Text style={styles.resultText}>
+              H: {measurement.height.toFixed(1)} {measurement.heightUnit}
+            </Text>
+            <Text style={styles.resultText}>
+              Distance: {measurement.distanceFromCamera.toFixed(2)} {measurement.distanceFromCameraUnit}
+            </Text>
+            <Text style={styles.resultText}>
+              Confidence: {(measurement.confidence * 100).toFixed(0)}%
+            </Text>
+            <Text style={styles.resultText}>
+              Cloud SAM: {String(measurement.usedCloudSAM)}
+            </Text>
+          </View>
+        ) : (
+          <Text style={styles.hint}>
+            Point camera at a box. A measurement will appear here when captured.
+          </Text>
+        )}
+      </ScrollView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 24 },
+  camera: { flex: 1 },
+  resultsPanel: {
+    maxHeight: 240,
+    backgroundColor: '#111',
+    padding: 12,
+  },
+  loadingText: { marginTop: 12, color: '#666' },
+  hint: { color: '#888', textAlign: 'center', marginTop: 16 },
+  errorBox: { backgroundColor: '#3a0000', borderRadius: 8, padding: 12, marginBottom: 8 },
+  errorLabel: { color: '#ff6b6b', fontWeight: 'bold', marginBottom: 4 },
+  errorText: { color: '#ff6b6b' },
+  errorReason: { color: '#ff9999', marginTop: 4, fontSize: 12 },
+  resultBox: { backgroundColor: '#1a2a1a', borderRadius: 8, padding: 12, marginBottom: 8 },
+  resultTitle: { color: '#4caf50', fontWeight: 'bold', marginBottom: 8 },
+  resultText: { color: '#ddd', marginBottom: 2 },
+  capText: { color: '#888', marginTop: 12, fontSize: 13, lineHeight: 20 },
+});
+
+export default DimensioningScreen;

--- a/example/src/HomeScreen.tsx
+++ b/example/src/HomeScreen.tsx
@@ -44,6 +44,17 @@ const HomeScreen = ({ navigation }) => {
             Camera-based barcode scanning and OCR
           </Text>
         </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.primaryButton}
+          onPress={() => navigation.navigate("DimensioningScreen")}
+        >
+          <Text style={styles.primaryButtonText}>Dimensioning</Text>
+          <Text style={styles.buttonDescription}>
+            3-D box measurement (iOS 17+ LiDAR only)
+          </Text>
+        </TouchableOpacity>
+
       </View>
 
       <View style={styles.footerContainer}>

--- a/example/src/ModelManagementScreen.tsx
+++ b/example/src/ModelManagementScreen.tsx
@@ -17,7 +17,9 @@ import type { VisionCameraCaptureEvent } from '../../src/VisionCamera';
 
 const CAPTURED_IMAGE_STORAGE_KEY = '@vision_sdk_captured_image';
 
-const api_key = ""; // Add your PackageX API key here
+// Load your PackageX API key from the environment.
+// Set PACKAGEX_API_KEY in a .env file (never commit real keys to source control).
+const api_key: string = (process.env.PACKAGEX_API_KEY as string) ?? "";
 
 // Sample barcodes array with iOS-format properties
 const SAMPLE_BARCODES: DetectedBarcode[] = [

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2017,9 +2017,9 @@ boolbase@^1.0.0:
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 brace-expansion@^1.1.12, brace-expansion@^1.1.7, brace-expansion@^2.0.1:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
-  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
+  version "1.1.13"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz"
+  integrity sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -2625,9 +2625,9 @@ fast-json-stable-stringify@^2.1.0:
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-xml-parser@^4.4.1:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz#c54d6b35aa0f23dc1ea60b6c884340c006dc6efb"
-  integrity sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==
+  version "4.5.5"
+  resolved "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.5.tgz"
+  integrity sha512-cK9c5I/DwIOI7/Q7AlGN3DuTdwN61gwSfL8rvuVPK+0mcCNHHGxRrpiFtaZZRfRMJL3Gl8B2AFlBG6qXf03w9A==
   dependencies:
     strnum "^1.1.1"
 
@@ -3842,23 +3842,23 @@ mimic-fn@^2.1.0:
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
 minimatch@^3.0.4, minimatch@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  version "3.1.5"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 
 minimatch@^8.0.2:
-  version "8.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-8.0.4.tgz#847c1b25c014d4e9a7f68aaf63dedd668a626229"
-  integrity sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==
+  version "8.0.7"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz"
+  integrity sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==
   dependencies:
     brace-expansion "^2.0.1"
 
 minimatch@^9.0.5:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
-  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
+  version "9.0.9"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -4127,14 +4127,14 @@ picocolors@^1.1.1:
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 picomatch@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pirates@^4.0.4:
   version "4.0.7"
@@ -5055,9 +5055,9 @@ yallist@^3.0.2:
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yaml@^2.2.1, yaml@^2.6.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.1.tgz#1870aa02b631f7e8328b93f8bc574fac5d6c4d79"
-  integrity sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==
+  version "2.8.3"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz"
+  integrity sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==
 
 yargs-parser@^18.1.2:
   version "18.1.3"

--- a/ios/DimensioningModule.swift
+++ b/ios/DimensioningModule.swift
@@ -1,0 +1,43 @@
+import Foundation
+import VisionSDK
+import VisionSDKDimensioning
+
+// MARK: - DimensioningModule
+//
+// Swift implementation of the DimensioningModule TurboModule.
+// Instantiated lazily by DimensioningModuleTurboModule.mm via NSClassFromString.
+// iOS-only: both methods delegate to VSDKDimensioning static helpers.
+
+@objc(DimensioningModule)
+class DimensioningModule: NSObject {
+
+  // MARK: - deviceCapabilities
+  @objc func deviceCapabilities(
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    let caps = VSDKDimensioning.deviceCapabilities()
+    let dict: [String: Any] = [
+      "lidar": caps.lidar,
+      "arWorldTracking": caps.arWorldTracking,
+      "sceneReconstruction": caps.sceneReconstruction
+    ]
+    guard let jsonData = try? JSONSerialization.data(withJSONObject: dict),
+          let jsonString = String(data: jsonData, encoding: .utf8) else {
+      rejecter("SERIALIZATION_ERROR", "Failed to serialise capabilities", nil)
+      return
+    }
+    resolver(jsonString)
+  }
+
+  // MARK: - prefetchModels
+  @objc func prefetchModels(
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    Task {
+      await VSDKDimensioning.prefetchModels()
+      resolver(nil)
+    }
+  }
+}

--- a/ios/DimensioningModuleTurboModule.h
+++ b/ios/DimensioningModuleTurboModule.h
@@ -1,0 +1,13 @@
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import <React/RCTEventEmitter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DimensioningModuleTurboModule : RCTEventEmitter
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // RCT_NEW_ARCH_ENABLED

--- a/ios/DimensioningModuleTurboModule.mm
+++ b/ios/DimensioningModuleTurboModule.mm
@@ -1,0 +1,87 @@
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import "DimensioningModuleTurboModule.h"
+#import <objc/message.h>
+
+@implementation DimensioningModuleTurboModule {
+  id _swiftModule;
+}
+
+RCT_EXPORT_MODULE(DimensioningModule)
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
+- (instancetype)init {
+  if (self = [super init]) {
+    _swiftModule = nil;
+  }
+  return self;
+}
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[];
+}
+
+- (void)startObserving {}
+- (void)stopObserving {}
+
+// Helper: lazy-init Swift DimensioningModule singleton
+- (id)getSwiftModule {
+  if (!_swiftModule) {
+    Class cls = NSClassFromString(@"DimensioningModule");
+    if (cls) {
+      _swiftModule = [[cls alloc] init];
+    }
+  }
+  return _swiftModule;
+}
+
+// MARK: - deviceCapabilities
+
+RCT_EXPORT_METHOD(deviceCapabilities:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+  id swiftModule = [self getSwiftModule];
+  if (!swiftModule) {
+    reject(@"MODULE_NOT_FOUND", @"DimensioningModule Swift class not found", nil);
+    return;
+  }
+
+  SEL selector = NSSelectorFromString(@"deviceCapabilitiesWithResolver:rejecter:");
+  if ([swiftModule respondsToSelector:selector]) {
+    ((void (*)(id, SEL, RCTPromiseResolveBlock, RCTPromiseRejectBlock))objc_msgSend)(
+      swiftModule, selector, resolve, reject
+    );
+  } else {
+    reject(@"NOT_IMPLEMENTED", @"deviceCapabilities not available", nil);
+  }
+}
+
+// MARK: - prefetchModels
+
+RCT_EXPORT_METHOD(prefetchModels:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+  id swiftModule = [self getSwiftModule];
+  if (!swiftModule) {
+    reject(@"MODULE_NOT_FOUND", @"DimensioningModule Swift class not found", nil);
+    return;
+  }
+
+  SEL selector = NSSelectorFromString(@"prefetchModelsWithResolver:rejecter:");
+  if ([swiftModule respondsToSelector:selector]) {
+    ((void (*)(id, SEL, RCTPromiseResolveBlock, RCTPromiseRejectBlock))objc_msgSend)(
+      swiftModule, selector, resolve, reject
+    );
+  } else {
+    reject(@"NOT_IMPLEMENTED", @"prefetchModels not available", nil);
+  }
+}
+
+@end
+
+#endif // RCT_NEW_ARCH_ENABLED

--- a/ios/Fabric/DimensioningViewComponentView.h
+++ b/ios/Fabric/DimensioningViewComponentView.h
@@ -1,0 +1,14 @@
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import <React/RCTViewComponentView.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DimensioningViewComponentView : RCTViewComponentView
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // RCT_NEW_ARCH_ENABLED

--- a/ios/Fabric/DimensioningViewComponentView.mm
+++ b/ios/Fabric/DimensioningViewComponentView.mm
@@ -1,0 +1,177 @@
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#import "DimensioningViewComponentView.h"
+
+#import <react/renderer/components/VisionSdkSpec/ComponentDescriptors.h>
+#import <react/renderer/components/VisionSdkSpec/EventEmitters.h>
+#import <react/renderer/components/VisionSdkSpec/Props.h>
+#import <react/renderer/components/VisionSdkSpec/RCTComponentViewHelpers.h>
+
+#import "RCTFabricComponentsPlugins.h"
+#import <objc/message.h>
+
+using namespace facebook::react;
+
+@interface DimensioningViewComponentView () <RCTDimensioningViewViewProtocol>
+@end
+
+@implementation DimensioningViewComponentView {
+  UIView *_dimensioningView;
+}
+
+// MARK: - Initialization
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps = std::make_shared<const DimensioningViewProps>();
+    _props = defaultProps;
+
+    // Instantiate the Swift view at runtime — avoids importing the bridging header
+    // (same technique as VisionCameraViewComponentView).
+    Class RNDimensioningViewClass = NSClassFromString(@"RNDimensioningView");
+    if (RNDimensioningViewClass) {
+      _dimensioningView = [[RNDimensioningViewClass alloc] initWithFrame:self.bounds];
+
+      __weak DimensioningViewComponentView *weakSelf = self;
+
+      // Wire onCapture
+      SEL onCaptureSetter = NSSelectorFromString(@"setOnCapture:");
+      if ([_dimensioningView respondsToSelector:onCaptureSetter]) {
+        id captureBlock = ^(NSDictionary *event) {
+          [weakSelf emitCaptureEvent:event];
+        };
+        ((void (*)(id, SEL, id))objc_msgSend)(_dimensioningView, onCaptureSetter, captureBlock);
+      }
+
+      // Wire onError
+      SEL onErrorSetter = NSSelectorFromString(@"setOnError:");
+      if ([_dimensioningView respondsToSelector:onErrorSetter]) {
+        id errorBlock = ^(NSDictionary *event) {
+          [weakSelf emitErrorEvent:event];
+        };
+        ((void (*)(id, SEL, id))objc_msgSend)(_dimensioningView, onErrorSetter, errorBlock);
+      }
+    } else {
+      // Fallback placeholder when Swift class not available (simulator without LiDAR)
+      _dimensioningView = [[UIView alloc] initWithFrame:self.bounds];
+      _dimensioningView.backgroundColor = [UIColor darkGrayColor];
+    }
+
+    _dimensioningView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.contentView = _dimensioningView;
+  }
+
+  return self;
+}
+
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+
+  _dimensioningView.frame = self.bounds;
+
+  if ([_dimensioningView respondsToSelector:@selector(layoutSubviews)]) {
+    [_dimensioningView performSelector:@selector(layoutSubviews)];
+  }
+}
+
+- (void)didMoveToWindow
+{
+  [super didMoveToWindow];
+
+  if (self.window) {
+    [self setNeedsLayout];
+    [self layoutIfNeeded];
+  }
+}
+
+- (void)prepareForRecycle
+{
+  [super prepareForRecycle];
+}
+
+// MARK: - RCTComponentViewProtocol
+
++ (ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return concreteComponentDescriptorProvider<DimensioningViewComponentDescriptor>();
+}
+
+// MARK: - Props handling
+
+- (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
+{
+  const auto &oldViewProps = *std::static_pointer_cast<DimensioningViewProps const>(_props);
+  const auto &newViewProps = *std::static_pointer_cast<DimensioningViewProps const>(props);
+
+  if (oldViewProps.mode != newViewProps.mode) {
+    SEL setter = NSSelectorFromString(@"setMode:");
+    if ([_dimensioningView respondsToSelector:setter]) {
+      NSString *value = [NSString stringWithUTF8String:newViewProps.mode.c_str()];
+      ((void (*)(id, SEL, id))objc_msgSend)(_dimensioningView, setter, value);
+    }
+  }
+
+  if (oldViewProps.measurementUnit != newViewProps.measurementUnit) {
+    SEL setter = NSSelectorFromString(@"setMeasurementUnit:");
+    if ([_dimensioningView respondsToSelector:setter]) {
+      NSString *value = [NSString stringWithUTF8String:newViewProps.measurementUnit.c_str()];
+      ((void (*)(id, SEL, id))objc_msgSend)(_dimensioningView, setter, value);
+    }
+  }
+
+  if (oldViewProps.maximumTrackCount != newViewProps.maximumTrackCount) {
+    SEL setter = NSSelectorFromString(@"setMaximumTrackCount:");
+    if ([_dimensioningView respondsToSelector:setter]) {
+      NSInteger value = (NSInteger)newViewProps.maximumTrackCount;
+      NSInvocation *inv = [NSInvocation invocationWithMethodSignature:
+        [_dimensioningView methodSignatureForSelector:setter]];
+      [inv setSelector:setter];
+      [inv setTarget:_dimensioningView];
+      [inv setArgument:&value atIndex:2];
+      [inv invoke];
+    }
+  }
+
+  [super updateProps:props oldProps:oldProps];
+}
+
+// MARK: - Event Emitters
+
+- (void)emitCaptureEvent:(NSDictionary *)eventData
+{
+  if (_eventEmitter != nullptr) {
+    auto emitter = std::static_pointer_cast<DimensioningViewEventEmitter const>(_eventEmitter);
+
+    DimensioningViewEventEmitter::OnCapture event = {};
+    if (NSString *measurementJson = [eventData objectForKey:@"measurementJson"]) {
+      event.measurementJson = std::string([measurementJson UTF8String]);
+    }
+    emitter->onCapture(event);
+  }
+}
+
+- (void)emitErrorEvent:(NSDictionary *)eventData
+{
+  if (_eventEmitter != nullptr) {
+    auto emitter = std::static_pointer_cast<DimensioningViewEventEmitter const>(_eventEmitter);
+
+    DimensioningViewEventEmitter::OnError event = {};
+    event.code = [[eventData objectForKey:@"code"] intValue];
+    event.message = std::string([[eventData objectForKey:@"message"] UTF8String] ?: "");
+    if (NSString *reason = [eventData objectForKey:@"reason"]) {
+      event.reason = std::string([reason UTF8String]);
+    }
+    emitter->onError(event);
+  }
+}
+
+@end
+
+Class<RCTComponentViewProtocol> DimensioningViewCls(void)
+{
+  return DimensioningViewComponentView.class;
+}
+
+#endif // RCT_NEW_ARCH_ENABLED

--- a/ios/Fabric/VisionCameraViewComponentView.mm
+++ b/ios/Fabric/VisionCameraViewComponentView.mm
@@ -278,6 +278,39 @@ using namespace facebook::react;
     }
   }
 
+  // Native bounding-box overlay props (requires VisionSDK >= pod bump that adds these properties)
+  if (oldViewProps.showCodeBoundingBoxes != newViewProps.showCodeBoundingBoxes) {
+    SEL setter = NSSelectorFromString(@"setShowCodeBoundingBoxes:");
+    if ([_visionCameraView respondsToSelector:setter]) {
+      BOOL value = newViewProps.showCodeBoundingBoxes;
+      ((void (*)(id, SEL, BOOL))objc_msgSend)(_visionCameraView, setter, value);
+    }
+  }
+
+  if (oldViewProps.barcodeBoundingBoxBorderColor != newViewProps.barcodeBoundingBoxBorderColor) {
+    SEL setter = NSSelectorFromString(@"setBarcodeBoundingBoxBorderColor:");
+    if ([_visionCameraView respondsToSelector:setter]) {
+      NSString *value = [NSString stringWithUTF8String:newViewProps.barcodeBoundingBoxBorderColor.c_str()];
+      ((void (*)(id, SEL, id))objc_msgSend)(_visionCameraView, setter, value);
+    }
+  }
+
+  if (oldViewProps.barcodeBoundingBoxBorderWidth != newViewProps.barcodeBoundingBoxBorderWidth) {
+    SEL setter = NSSelectorFromString(@"setBarcodeBoundingBoxBorderWidth:");
+    if ([_visionCameraView respondsToSelector:setter]) {
+      NSNumber *value = @(newViewProps.barcodeBoundingBoxBorderWidth);
+      ((void (*)(id, SEL, id))objc_msgSend)(_visionCameraView, setter, value);
+    }
+  }
+
+  if (oldViewProps.barcodeBoundingBoxFillColor != newViewProps.barcodeBoundingBoxFillColor) {
+    SEL setter = NSSelectorFromString(@"setBarcodeBoundingBoxFillColor:");
+    if ([_visionCameraView respondsToSelector:setter]) {
+      NSString *value = [NSString stringWithUTF8String:newViewProps.barcodeBoundingBoxFillColor.c_str()];
+      ((void (*)(id, SEL, id))objc_msgSend)(_visionCameraView, setter, value);
+    }
+  }
+
   [super updateProps:props oldProps:oldProps];
 }
 

--- a/ios/RNDimensioningView.swift
+++ b/ios/RNDimensioningView.swift
@@ -1,0 +1,170 @@
+import UIKit
+import VisionSDK
+import VisionSDKDimensioning
+
+// MARK: - RNDimensioningView
+//
+// Swift UIView subclass that wraps VSDKDimensioningView from the
+// VisionSDK/Dimensioning CocoaPods subspec.
+//
+// Design notes:
+//  - No compile-time guards (#if) anywhere in this file. All availability
+//    checks happen at runtime via `VSDKDimensioning.deviceCapabilities().lidar`
+//    and the @available(iOS 17, *) attribute on the inner start/stop helpers.
+//  - Event blocks (onCapture, onError) are set by the Fabric ComponentView
+//    via objc_msgSend before the view is laid out, mirroring the scanner pattern.
+
+@objc(RNDimensioningView)
+class RNDimensioningView: UIView {
+
+  // MARK: - Event blocks (wired by DimensioningViewComponentView.mm)
+  @objc var onCapture: RCTDirectEventBlock?
+  @objc var onError: RCTDirectEventBlock?
+
+  // MARK: - Props
+  @objc var mode: NSString = "offline" {
+    didSet { reconfigure() }
+  }
+
+  @objc var measurementUnit: NSString = "centimeters" {
+    didSet { reconfigure() }
+  }
+
+  @objc var maximumTrackCount: NSInteger = 5 {
+    didSet { reconfigure() }
+  }
+
+  // MARK: - Private state
+  private var dimView: VSDKDimensioningView?
+  private var isSetupComplete = false
+
+  // MARK: - Init
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: - Layout
+  override func layoutSubviews() {
+    super.layoutSubviews()
+
+    if !isSetupComplete && bounds.size.width > 0 && bounds.size.height > 0 {
+      isSetupComplete = true
+      setupDimensioningView()
+    }
+
+    dimView?.frame = bounds
+  }
+
+  // MARK: - Setup
+  private func setupDimensioningView() {
+    guard #available(iOS 17.0, *) else {
+      sendError(code: 2, message: "Dimensioning requires iOS 17.0 or later.", reason: nil)
+      return
+    }
+
+    let caps = VSDKDimensioning.deviceCapabilities()
+    guard caps.lidar else {
+      sendError(code: 2, message: "Dimensioning requires a LiDAR-equipped device.", reason: nil)
+      return
+    }
+
+    startDimensioning()
+  }
+
+  @available(iOS 17.0, *)
+  private func startDimensioning() {
+    let dv = VSDKDimensioningView(frame: bounds)
+    dv.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
+    let selectedMode: VSDKDimensioningMode = (mode as String).lowercased() == "online" ? .online : .offline
+    dv.configure(
+      delegate: self,
+      mode: selectedMode,
+      maximumTrackCount: maximumTrackCount
+    )
+
+    addSubview(dv)
+    dimView = dv
+    dv.startRunning()
+  }
+
+  // MARK: - Reconfigure on prop change
+  private func reconfigure() {
+    guard isSetupComplete else { return }
+    guard #available(iOS 17.0, *) else { return }
+
+    dimView?.stopRunning()
+    dimView?.removeFromSuperview()
+    dimView = nil
+
+    setupDimensioningView()
+  }
+
+  // MARK: - Lifecycle
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+
+    guard isSetupComplete, #available(iOS 17.0, *) else { return }
+
+    if window != nil {
+      dimView?.startRunning()
+    } else {
+      dimView?.stopRunning()
+    }
+  }
+
+  // MARK: - Helpers
+  private func sendError(code: Int, message: String, reason: String?) {
+    guard let onError = onError else { return }
+    var payload: [String: Any] = ["code": code, "message": message]
+    if let reason = reason { payload["reason"] = reason }
+    onError(payload)
+  }
+
+  deinit {
+    if #available(iOS 17.0, *) {
+      dimView?.stopRunning()
+    }
+  }
+}
+
+// MARK: - VSDKDimensioningViewDelegate
+extension RNDimensioningView: VSDKDimensioningViewDelegate {
+
+  func dimensioningView(_ view: VSDKDimensioningView, didCapture measurement: VSDKDimensioningMeasurement) {
+    guard let onCapture = onCapture else { return }
+
+    // Serialise measurement to a JSON string so the Fabric event emitter
+    // can pass it as a plain string field (avoids C++ nested struct codegen).
+    let dict: [String: Any] = [
+      "id": measurement.id.uuidString,
+      "timestamp": measurement.timestamp.timeIntervalSince1970,
+      "length": measurement.length.doubleValue,
+      "lengthUnit": measurement.length.unit.symbol,
+      "width": measurement.width.doubleValue,
+      "widthUnit": measurement.width.unit.symbol,
+      "height": measurement.height.doubleValue,
+      "heightUnit": measurement.height.unit.symbol,
+      "distanceFromCamera": measurement.distanceFromCamera.doubleValue,
+      "distanceFromCameraUnit": measurement.distanceFromCamera.unit.symbol,
+      "confidence": measurement.confidence,
+      "usedCloudSAM": measurement.usedCloudSAM
+    ]
+
+    guard let jsonData = try? JSONSerialization.data(withJSONObject: dict),
+          let jsonString = String(data: jsonData, encoding: .utf8) else {
+      sendError(code: -1, message: "Failed to serialise measurement", reason: nil)
+      return
+    }
+
+    onCapture(["measurementJson": jsonString])
+  }
+
+  func dimensioningView(_ view: VSDKDimensioningView, didFailWithError error: NSError) {
+    sendError(code: error.code, message: error.localizedDescription, reason: error.userInfo["reason"] as? String)
+  }
+}

--- a/ios/RNDimensioningView.swift
+++ b/ios/RNDimensioningView.swift
@@ -157,7 +157,9 @@ extension RNDimensioningView: VSDKDimensioningViewDelegate {
 
     guard let jsonData = try? JSONSerialization.data(withJSONObject: dict),
           let jsonString = String(data: jsonData, encoding: .utf8) else {
-      sendError(code: -1, message: "Failed to serialise measurement", reason: nil)
+      // 7 = DimensioningErrorCode.InternalError (bridge/serialization failure;
+      // not a real VSDKDimensioningError).
+      sendError(code: 7, message: "Failed to serialise measurement", reason: nil)
       return
     }
 

--- a/ios/RNVisionCameraView.swift
+++ b/ios/RNVisionCameraView.swift
@@ -116,6 +116,34 @@ class RNVisionCameraView: UIView {
     }
   }
 
+  @objc var showCodeBoundingBoxes: Bool = false {
+    didSet {
+      cameraView?.showCodeBoundingBoxes = showCodeBoundingBoxes
+    }
+  }
+
+  @objc var barcodeBoundingBoxBorderColor: NSString? {
+    didSet {
+      if let color = Self.parseARGBColor(barcodeBoundingBoxBorderColor as String?) {
+        cameraView?.barcodeBoundingBoxBorderColor = color
+      }
+    }
+  }
+
+  @objc var barcodeBoundingBoxBorderWidth: NSNumber = 3.0 {
+    didSet {
+      cameraView?.barcodeBoundingBoxBorderWidth = CGFloat(truncating: barcodeBoundingBoxBorderWidth)
+    }
+  }
+
+  @objc var barcodeBoundingBoxFillColor: NSString? {
+    didSet {
+      if let color = Self.parseARGBColor(barcodeBoundingBoxFillColor as String?) {
+        cameraView?.barcodeBoundingBoxFillColor = color
+      }
+    }
+  }
+
   // MARK: - VisionSDK Components
   var cameraView: CodeScannerView?
   private var currentScanMode: CodeScannerMode = .photo
@@ -460,6 +488,7 @@ class RNVisionCameraView: UIView {
   }
 
   /// Parses a hex color string (e.g., "#ff0000", "#ff000080") into a UIColor.
+  /// For 8-digit strings, the format is RRGGBBAA (alpha last).
   private static func parseColor(_ hex: String?) -> UIColor? {
     guard let hex = hex else { return nil }
     let cleanHex = hex.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "#", with: "")
@@ -478,6 +507,33 @@ class RNVisionCameraView: UIView {
       let g = CGFloat((hexValue & 0x00FF0000) >> 16) / 255.0
       let b = CGFloat((hexValue & 0x0000FF00) >> 8) / 255.0
       let a = CGFloat(hexValue & 0x000000FF) / 255.0
+      return UIColor(red: r, green: g, blue: b, alpha: a)
+    }
+    return nil
+  }
+
+  /// Parses a hex color string in Android AARRGGBB format (e.g., "#8B5CF6", "#338B5CF6") into a UIColor.
+  /// For 6-digit strings (#RRGGBB), alpha defaults to 1.0 (fully opaque).
+  /// For 8-digit strings (#AARRGGBB), the first byte is alpha — matching Android's Color.parseColor behaviour.
+  private static func parseARGBColor(_ hex: String?) -> UIColor? {
+    guard let hex = hex else { return nil }
+    let cleanHex = hex.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "#", with: "")
+
+    var hexValue: UInt64 = 0
+    let scanner = Scanner(string: cleanHex)
+    guard scanner.scanHexInt64(&hexValue) else { return nil }
+
+    if cleanHex.count == 6 {
+      let r = CGFloat((hexValue & 0xFF0000) >> 16) / 255.0
+      let g = CGFloat((hexValue & 0x00FF00) >> 8) / 255.0
+      let b = CGFloat(hexValue & 0x0000FF) / 255.0
+      return UIColor(red: r, green: g, blue: b, alpha: 1.0)
+    } else if cleanHex.count == 8 {
+      // AARRGGBB — alpha occupies the most-significant byte
+      let a = CGFloat((hexValue & 0xFF000000) >> 24) / 255.0
+      let r = CGFloat((hexValue & 0x00FF0000) >> 16) / 255.0
+      let g = CGFloat((hexValue & 0x0000FF00) >> 8) / 255.0
+      let b = CGFloat(hexValue & 0x000000FF) / 255.0
       return UIColor(red: r, green: g, blue: b, alpha: a)
     }
     return nil

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     },
     "ios": {
       "componentProvider": {
-        "VisionCameraView": "VisionCameraViewComponentView"
+        "VisionCameraView": "VisionCameraViewComponentView",
+        "DimensioningView": "DimensioningViewComponentView"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-sdk",
-  "version": "3.0.10",
+  "version": "3.1.0",
   "description": "VisionSDK for React Native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -111,9 +111,20 @@
   },
   "resolutions": {
     "@types/react": "^19.0.0",
-    "brace-expansion": "^1.1.12",
+    "brace-expansion": "^1.1.13",
     "handlebars": "^4.7.9",
-    "flatted": "^3.4.2"
+    "flatted": "^3.4.2",
+    "minimatch": "^3.1.5",
+    "micromatch/minimatch": "^5.1.8",
+    "react-native-builder-bob/glob/minimatch": "^5.1.8",
+    "babel-plugin-module-resolver/glob/minimatch": "^8.0.6",
+    "undici": "^6.25.0",
+    "basic-ftp": "^5.2.2",
+    "lodash": "^4.18.0",
+    "defu": "^6.1.5",
+    "fast-uri": "^3.1.2",
+    "ip-address": "^10.1.1",
+    "@babel/plugin-transform-modules-systemjs": "^7.29.4"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -10,11 +10,12 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  # Dimensioning subspec requires iOS 17; set deployment target accordingly.
-  # The core scanner supports iOS 16 but all devices that run iOS 17 also
-  # support running the scanner path, so bumping to 17 is acceptable for
-  # the example app. The production podspec can remain at 16 by excluding
-  # the Dimensioning files via subspecs (see README).
+  # iOS 17 is required because the `VisionSDK/Dimensioning` subspec we
+  # depend on below links ARKit/RealityKit and the LiDAR pipeline. The
+  # core scanner alone supports iOS 16, but Dimensioning is currently a
+  # hard dependency of this pod, so the deployment target is 17.0 for
+  # all consumers. Splitting Dimensioning into a separate optional pod
+  # (so non-LiDAR consumers can stay on iOS 16) is a follow-up.
   s.platforms    = { :ios => "17.0" }
   s.source       = { :git => "https://github.com/packagex-io/react-native-vision-sdk.git", :tag => "#{s.version}" }
 

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -10,7 +10,12 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "16.0" }
+  # Dimensioning subspec requires iOS 17; set deployment target accordingly.
+  # The core scanner supports iOS 16 but all devices that run iOS 17 also
+  # support running the scanner path, so bumping to 17 is acceptable for
+  # the example app. The production podspec can remain at 16 by excluding
+  # the Dimensioning files via subspecs (see README).
+  s.platforms    = { :ios => "17.0" }
   s.source       = { :git => "https://github.com/packagex-io/react-native-vision-sdk.git", :tag => "#{s.version}" }
 
   # Explicitly set module name to ensure Swift bridging header matches
@@ -19,7 +24,7 @@ Pod::Spec.new do |s|
   # Static framework configuration for Swift/ObjC interop
   s.static_framework = true
 
-  # New Architecture only - include all source files
+  # All iOS source files including Dimensioning bridge
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   # Compiler flags to ensure Swift bridging header is found
@@ -39,7 +44,10 @@ Pod::Spec.new do |s|
   s.frameworks = "CoreMotion"
 
   s.dependency "React-Core"
-  s.dependency "VisionSDK", "= 2.2.1"
+  # Core scanner + OCR
+  s.dependency "VisionSDK", "= 2.3.0"
+  # 3-D box measurement — brings MVDimensioningCore.xcframework, ARKit, RealityKit, PostHog
+  s.dependency "VisionSDK/Dimensioning", "= 2.3.0"
 
   # New Architecture dependencies
   install_modules_dependencies(s)

--- a/src/dimensioning/DimensioningView.tsx
+++ b/src/dimensioning/DimensioningView.tsx
@@ -1,0 +1,85 @@
+/**
+ * DimensioningView
+ *
+ * NOTE: Dimensioning is iOS-only. On iOS 17+ LiDAR devices this renders the
+ * native VSDKDimensioningView. On all other platforms (Android, older iOS,
+ * simulator) it renders an empty placeholder View.
+ *
+ * Gate rendering at the call site:
+ *   const caps = await VisionDimensioning.deviceCapabilities();
+ *   if (caps.lidar) { ... render <DimensioningView> ... }
+ */
+
+import React from 'react';
+import { Platform, View, type ViewStyle } from 'react-native';
+import type { DimensioningMeasurement, DimensioningError, DimensioningMode } from './types';
+import NativeDimensioningView from '../specs/DimensioningViewNativeComponent';
+
+export interface DimensioningViewProps {
+  style?: ViewStyle;
+
+  /** Processing mode. Default: 'offline'. */
+  mode?: DimensioningMode;
+
+  /** Measurement unit requested. Default: 'centimeters'. */
+  measurementUnit?: string;
+
+  /** Maximum number of simultaneous tracked objects. Default: 5. */
+  maximumTrackCount?: number;
+
+  /** Called when a stable measurement is captured. */
+  onCapture?: (measurement: DimensioningMeasurement) => void;
+
+  /** Called when an error occurs in the native view. */
+  onError?: (error: DimensioningError) => void;
+}
+
+/**
+ * <DimensioningView> — iOS-only 3-D box measurement component.
+ *
+ * Renders the native VSDKDimensioningView on iOS 17+ LiDAR devices.
+ * Falls back to an empty View on Android and non-LiDAR / pre-iOS-17 devices
+ * (the JS layer is expected to gate entry via deviceCapabilities()).
+ */
+export function DimensioningView({
+  style,
+  mode = 'offline',
+  measurementUnit = 'centimeters',
+  maximumTrackCount = 5,
+  onCapture,
+  onError,
+}: DimensioningViewProps) {
+  if (Platform.OS !== 'ios') {
+    return <View style={style} />;
+  }
+
+  const handleCapture = onCapture
+    ? (event: { nativeEvent: { measurementJson: string } }) => {
+        try {
+          const measurement: DimensioningMeasurement = JSON.parse(
+            event.nativeEvent.measurementJson
+          );
+          onCapture(measurement);
+        } catch {
+          // malformed JSON from native — silently drop
+        }
+      }
+    : undefined;
+
+  const handleError = onError
+    ? (event: { nativeEvent: { code: number; message: string; reason?: string } }) => {
+        onError(event.nativeEvent);
+      }
+    : undefined;
+
+  return (
+    <NativeDimensioningView
+      style={style}
+      mode={mode}
+      measurementUnit={measurementUnit}
+      maximumTrackCount={maximumTrackCount}
+      onCapture={handleCapture}
+      onError={handleError}
+    />
+  );
+}

--- a/src/dimensioning/DimensioningView.tsx
+++ b/src/dimensioning/DimensioningView.tsx
@@ -2,8 +2,10 @@
  * DimensioningView
  *
  * NOTE: Dimensioning is iOS-only. On iOS 17+ LiDAR devices this renders the
- * native VSDKDimensioningView. On all other platforms (Android, older iOS,
- * simulator) it renders an empty placeholder View.
+ * native VSDKDimensioningView. On Android the native side renders a
+ * "not supported on this platform" placeholder TextView; capture/error
+ * callbacks never fire there. On non-LiDAR iOS devices the iOS native side
+ * calls onError with LidarUnavailable.
  *
  * Gate rendering at the call site:
  *   const caps = await VisionDimensioning.deviceCapabilities();
@@ -11,7 +13,7 @@
  */
 
 import React from 'react';
-import { Platform, View, type ViewStyle } from 'react-native';
+import { type ViewStyle } from 'react-native';
 import type { DimensioningMeasurement, DimensioningError, DimensioningMode } from './types';
 import NativeDimensioningView from '../specs/DimensioningViewNativeComponent';
 
@@ -21,25 +23,39 @@ export interface DimensioningViewProps {
   /** Processing mode. Default: 'offline'. */
   mode?: DimensioningMode;
 
-  /** Measurement unit requested. Default: 'centimeters'. */
+  /**
+   * Measurement unit requested.
+   *
+   * **Known limitation**: this prop is currently not honored on iOS. The native
+   * SDK's convenience `configure(delegate:mode:maximumTrackCount:)` hard-codes
+   * centimeters. Captures always come back in `cm` (visible on each
+   * measurement's `lengthUnit` / `widthUnit` / `heightUnit` fields).
+   * Will be wired through `VSDKDimensioningConfiguration` in a future release.
+   *
+   * @default 'centimeters'
+   */
   measurementUnit?: string;
 
   /** Maximum number of simultaneous tracked objects. Default: 5. */
   maximumTrackCount?: number;
 
-  /** Called when a stable measurement is captured. */
+  /** Called when a stable measurement is captured. iOS only. */
   onCapture?: (measurement: DimensioningMeasurement) => void;
 
-  /** Called when an error occurs in the native view. */
+  /** Called when an error occurs in the native view. iOS only. */
   onError?: (error: DimensioningError) => void;
 }
 
 /**
- * <DimensioningView> — iOS-only 3-D box measurement component.
+ * <DimensioningView> — 3-D box measurement component.
  *
- * Renders the native VSDKDimensioningView on iOS 17+ LiDAR devices.
- * Falls back to an empty View on Android and non-LiDAR / pre-iOS-17 devices
- * (the JS layer is expected to gate entry via deviceCapabilities()).
+ * Renders the native Fabric component on both iOS and Android:
+ *  - **iOS 17+ LiDAR**: live VSDKDimensioningView with capture/error events.
+ *  - **iOS without LiDAR**: native view calls onError with LidarUnavailable (code 2).
+ *  - **Android**: native side renders a placeholder TextView (no events).
+ *
+ * Gate entry on `VisionDimensioning.deviceCapabilities()` to avoid mounting
+ * the view on unsupported devices.
  */
 export function DimensioningView({
   style,
@@ -49,10 +65,6 @@ export function DimensioningView({
   onCapture,
   onError,
 }: DimensioningViewProps) {
-  if (Platform.OS !== 'ios') {
-    return <View style={style} />;
-  }
-
   const handleCapture = onCapture
     ? (event: { nativeEvent: { measurementJson: string } }) => {
         try {
@@ -60,8 +72,14 @@ export function DimensioningView({
             event.nativeEvent.measurementJson
           );
           onCapture(measurement);
-        } catch {
-          // malformed JSON from native — silently drop
+        } catch (err) {
+          // Surface the parse failure to onError instead of silently swallowing it,
+          // so consumers aren't left waiting for a capture that will never arrive.
+          onError?.({
+            code: 7,
+            message: 'Failed to parse measurement payload from native',
+            reason: err instanceof Error ? err.message : String(err),
+          });
         }
       }
     : undefined;

--- a/src/dimensioning/VisionDimensioning.ts
+++ b/src/dimensioning/VisionDimensioning.ts
@@ -1,0 +1,43 @@
+/**
+ * VisionDimensioning — static helpers for the dimensioning feature.
+ *
+ * NOTE: Both methods are iOS-only. On Android the TurboModule is not
+ * registered and the calls will throw "Native module DimensioningModule
+ * not found". Guard calls with `Platform.OS === 'ios'` at the call site,
+ * or catch the error.
+ */
+
+import NativeDimensioningModule from '../specs/NativeDimensioningModule';
+import type { DimensioningCapabilities } from './types';
+
+/**
+ * Returns the device's dimensioning capability flags.
+ * iOS-only.
+ *
+ * @returns Parsed DimensioningCapabilities object.
+ */
+export async function deviceCapabilities(): Promise<DimensioningCapabilities> {
+  if (!NativeDimensioningModule) {
+    throw new Error('DimensioningModule is not available on this platform.');
+  }
+  const json = await NativeDimensioningModule.deviceCapabilities();
+  return JSON.parse(json) as DimensioningCapabilities;
+}
+
+/**
+ * Pre-warm the bundled CoreML models for the dimensioning pipeline.
+ * Call once on app launch (after setting VSDKConstants.apiKey if using
+ * online mode). Cheap and idempotent on subsequent calls.
+ * iOS-only.
+ */
+export async function prefetchModels(): Promise<void> {
+  if (!NativeDimensioningModule) {
+    throw new Error('DimensioningModule is not available on this platform.');
+  }
+  await NativeDimensioningModule.prefetchModels();
+}
+
+export const VisionDimensioning = {
+  deviceCapabilities,
+  prefetchModels,
+};

--- a/src/dimensioning/VisionDimensioning.ts
+++ b/src/dimensioning/VisionDimensioning.ts
@@ -1,10 +1,11 @@
 /**
  * VisionDimensioning — static helpers for the dimensioning feature.
  *
- * NOTE: Both methods are iOS-only. On Android the TurboModule is not
- * registered and the calls will throw "Native module DimensioningModule
- * not found". Guard calls with `Platform.OS === 'ios'` at the call site,
- * or catch the error.
+ * **Dimensioning is iOS-only.** On Android the TurboModule is registered
+ * as a stub that resolves with all-false capabilities (and prefetchModels
+ * is a no-op), so these methods are safe to call cross-platform — they
+ * just don't do anything useful on Android. Use the result of
+ * `deviceCapabilities()` to decide whether to expose any dimensioning UI.
  */
 
 import NativeDimensioningModule from '../specs/NativeDimensioningModule';

--- a/src/dimensioning/index.ts
+++ b/src/dimensioning/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Dimensioning barrel.
+ *
+ * NOTE: Dimensioning is iOS-only. The <DimensioningView> component and
+ * VisionDimensioning helpers only function on iOS 17+ LiDAR devices.
+ */
+
+export { DimensioningView } from './DimensioningView';
+export type { DimensioningViewProps } from './DimensioningView';
+export { VisionDimensioning, deviceCapabilities, prefetchModels } from './VisionDimensioning';
+export { DimensioningErrorCode } from './types';
+export type {
+  DimensioningMeasurement,
+  DimensioningError,
+  DimensioningMode,
+  DimensioningMeasurementUnit,
+  DimensioningCapabilities,
+} from './types';

--- a/src/dimensioning/types.ts
+++ b/src/dimensioning/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Types for the Dimensioning feature.
+ * NOTE: Dimensioning is iOS-only. All types are usable cross-platform,
+ * but the native view and module only function on iOS 17+ LiDAR devices.
+ */
+
+export type DimensioningMode = 'offline' | 'online';
+
+export type DimensioningMeasurementUnit = 'centimeters' | 'inches' | 'meters';
+
+/**
+ * Error codes returned by the dimensioning native layer.
+ * Values match VSDKDimensioningError ordinals in the iOS SDK.
+ */
+export enum DimensioningErrorCode {
+  MissingCredentials = 0,
+  NotConfigured = 1,
+  LidarUnavailable = 2,
+  ArSessionFailed = 3,
+  NoGroundPlane = 4,
+  CaptureTimedOut = 5,
+  UserCancelled = 6,
+}
+
+/** A single dimension measurement returned by onCapture. */
+export interface DimensioningMeasurement {
+  id: string;
+  timestamp: number; // Unix seconds
+  length: number;
+  lengthUnit: string;
+  width: number;
+  widthUnit: string;
+  height: number;
+  heightUnit: string;
+  distanceFromCamera: number;
+  distanceFromCameraUnit: string;
+  confidence: number; // 0.0 – 1.0
+  usedCloudSAM: boolean;
+}
+
+export interface DimensioningError {
+  code: number;
+  message: string;
+  reason?: string;
+}
+
+/** Returned by VisionDimensioning.deviceCapabilities(). iOS-only. */
+export interface DimensioningCapabilities {
+  lidar: boolean;
+  arWorldTracking: boolean;
+  sceneReconstruction: boolean;
+}

--- a/src/dimensioning/types.ts
+++ b/src/dimensioning/types.ts
@@ -20,6 +20,8 @@ export enum DimensioningErrorCode {
   NoGroundPlane = 4,
   CaptureTimedOut = 5,
   UserCancelled = 6,
+  /** Bridge / serialization failure (not from the underlying VSDKDimensioningError). */
+  InternalError = 7,
 }
 
 /** A single dimension measurement returned by onCapture. */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,3 +2,4 @@ export * from './types';
 export * from './VisionCore';
 export { VisionCamera } from './VisionCamera';
 export * from './VisionCameraTypes';
+export * from './dimensioning';

--- a/src/specs/DimensioningViewNativeComponent.ts
+++ b/src/specs/DimensioningViewNativeComponent.ts
@@ -1,0 +1,34 @@
+import type { HostComponent, ViewProps } from 'react-native';
+import type {
+  DirectEventHandler,
+  Int32,
+  WithDefault,
+} from 'react-native/Libraries/Types/CodegenTypes';
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+
+// Event type definitions
+
+type DimensioningCaptureEvent = Readonly<{
+  // Measurement result serialised as JSON to avoid codegen object-nesting limitations
+  measurementJson: string;
+}>;
+
+type DimensioningErrorEvent = Readonly<{
+  code: Int32;
+  message: string;
+  reason?: string;
+}>;
+
+// Component props
+export interface NativeDimensioningProps extends ViewProps {
+  mode?: WithDefault<string, 'offline'>; // 'offline' | 'online'
+  measurementUnit?: WithDefault<string, 'centimeters'>;
+  maximumTrackCount?: Int32;
+
+  onCapture?: DirectEventHandler<DimensioningCaptureEvent>;
+  onError?: DirectEventHandler<DimensioningErrorEvent>;
+}
+
+export default codegenNativeComponent<NativeDimensioningProps>(
+  'DimensioningView'
+) as HostComponent<NativeDimensioningProps>;

--- a/src/specs/NativeDimensioningModule.ts
+++ b/src/specs/NativeDimensioningModule.ts
@@ -1,0 +1,25 @@
+import type { TurboModule } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
+
+/**
+ * TurboModule interface for static dimensioning helpers.
+ * NOTE: These methods are iOS-only. Calling from Android returns
+ * a rejected promise / default values.
+ */
+export interface Spec extends TurboModule {
+  /**
+   * Returns a JSON-encoded VSDKDimensioningCapabilities object.
+   * Fields: { lidar: boolean, arWorldTracking: boolean, sceneReconstruction: boolean }
+   * iOS-only.
+   */
+  deviceCapabilities(): Promise<string>;
+
+  /**
+   * Pre-warm the bundled CoreML dimensioning models so the first capture
+   * session doesn't pay JIT-compile cost. Safe to call multiple times.
+   * iOS-only.
+   */
+  prefetchModels(): Promise<void>;
+}
+
+export default TurboModuleRegistry.get<Spec>('DimensioningModule');

--- a/src/specs/NativeDimensioningModule.ts
+++ b/src/specs/NativeDimensioningModule.ts
@@ -3,8 +3,10 @@ import { TurboModuleRegistry } from 'react-native';
 
 /**
  * TurboModule interface for static dimensioning helpers.
- * NOTE: These methods are iOS-only. Calling from Android returns
- * a rejected promise / default values.
+ * NOTE: Dimensioning is iOS-only. The module is registered on both
+ * platforms; on Android the implementation is a stub that resolves
+ * `deviceCapabilities()` with all-false flags and `prefetchModels()`
+ * with `undefined`.
  */
 export interface Spec extends TurboModule {
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -720,9 +720,9 @@
     "@babel/helper-plugin-utils" "^7.27.1"
 
 "@babel/plugin-transform-modules-systemjs@^7.28.5":
-  version "7.28.5"
-  resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.28.5.tgz"
-  integrity sha512-vn5Jma98LCOeBy/KpeQhXcV2WZgaRUtjwQmjoBuLNlOmkg0fB5pdvYVeWRYI69wWKwK2cD1QbMiUQnoujWvrew==
+  version "7.29.4"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz"
+  integrity sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==
   dependencies:
     "@babel/helper-module-transforms" "^7.28.3"
     "@babel/helper-plugin-utils" "^7.27.1"
@@ -2932,9 +2932,9 @@ baseline-browser-mapping@^2.8.25:
   integrity sha512-gYjt7OIqdM0PcttNYP2aVrr2G0bMALkBaoehD4BuRGjAOtipg0b6wHg1yNL+s5zSnLZZrGHOw4IrND8CD+3oIQ==
 
 basic-ftp@^5.0.2:
-  version "5.0.5"
-  resolved "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz"
-  integrity sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==
+  version "5.3.1"
+  resolved "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz"
+  integrity sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==
 
 before-after-hook@^4.0.0:
   version "4.0.0"
@@ -3581,9 +3581,9 @@ define-properties@^1.1.3, define-properties@^1.2.1:
     object-keys "^1.1.1"
 
 defu@^6.1.4:
-  version "6.1.4"
-  resolved "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz"
-  integrity sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==
+  version "6.1.7"
+  resolved "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz"
+  integrity sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==
 
 degenerator@^5.0.0:
   version "5.0.1"
@@ -4248,9 +4248,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz"
-  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fastq@^1.6.0:
   version "1.19.1"
@@ -4906,9 +4906,9 @@ invariant@^2.2.4:
     loose-envify "^1.0.0"
 
 ip-address@^10.0.1:
-  version "10.1.0"
-  resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz"
-  integrity sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==
+  version "10.2.0"
+  resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz"
+  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
 
 is-absolute@^1.0.0:
   version "1.0.0"
@@ -5952,9 +5952,9 @@ lodash.upperfirst@^4.3.1:
   integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
 lodash@^4.15.0, lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+  version "4.18.1"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^7.0.1:
   version "7.0.1"
@@ -6528,23 +6528,23 @@ minimatch@^10.2.2:
     brace-expansion "^5.0.5"
 
 minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  version "3.1.5"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
 
 minimatch@^5.0.1:
-  version "5.1.6"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz"
-  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  version "5.1.9"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz"
+  integrity sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==
   dependencies:
     brace-expansion "^2.0.1"
 
 minimatch@^8.0.2:
-  version "8.0.4"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz"
-  integrity sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==
+  version "8.0.7"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz"
+  integrity sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==
   dependencies:
     brace-expansion "^2.0.1"
 
@@ -8366,9 +8366,9 @@ undici-types@~7.16.0:
   integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 undici@6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.23.0.tgz#7953087744d9095a96f115de3140ca3828aff3a4"
-  integrity sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==
+  version "6.25.0"
+  resolved "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz"
+  integrity sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## Summary

Bundles three coherent pieces that all needed to land together:

1. **iOS LiDAR dimensioning bridge** — new `<DimensioningView>` component + `VisionDimensioning` TurboModule wrapping the just-published VisionSDK 2.3.0 `Dimensioning` subspec.
2. **Android stub** for the same JS surface — Android has no LiDAR, so the TurboModule returns all-false capabilities and the view renders a "not supported on this platform" placeholder.
3. **Pre-existing security/deps cleanup** from the original `chore/security-audit-and-deps` branch (Dependabot resolutions, Android coord hardening, scanner bbox overlay props that were waiting on VisionSDK iOS to ship the feature).

Native deps updated: VisionSDK iOS `2.3.0` (Core + Dimensioning subspecs), vision-sdk-android `v2.4.48`.

## What's in

### iOS (Fabric)
- `ios/RNDimensioningView.swift` — `@objc(RNDimensioningView)` UIView wrapping `VSDKDimensioningView`, runtime LiDAR / iOS 17 gating
- `ios/Fabric/DimensioningViewComponentView.{h,mm}` — Fabric ComponentView using `NSClassFromString` + `objc_msgSend` (mirrors the scanner pattern, no bridging-header dep)
- `ios/DimensioningModule.swift` + `ios/DimensioningModuleTurboModule.{h,mm}` — static helpers TurboModule (`deviceCapabilities`, `prefetchModels`)

### Android (stub)
- `android/.../dimensioning/DimensioningModule.kt` — TurboModule, capabilities always false, prefetch is no-op
- `android/.../dimensioning/DimensioningViewManager.kt` — `SimpleViewManager<TextView>` placeholder
- `VisionSdkPackage.kt` — registers both

### JS / TS
- `src/dimensioning/` — `DimensioningView`, `VisionDimensioning` namespace, types, error-code enum
- `src/specs/` — codegen specs for the Fabric component + TurboModule
- `package.json` — `codegenConfig.ios.componentProvider` adds `DimensioningView`

### Example app
- New `DimensioningScreen` with capability check, capture display, error handling
- `App.tsx` + `HomeScreen.tsx` wired

### Docs
- `README.md` — new top-level **Dimensioning (3D Box Measurement, iOS only)** section: install, props, measurement shape, error table, capture-condition guidance.

## How to use (consumer)

```tsx
import { VisionDimensioning, DimensioningView } from 'react-native-vision-sdk';

// At app launch (no-op on Android)
await VisionDimensioning.prefetchModels();

// Capability check
const caps = await VisionDimensioning.deviceCapabilities();
if (!caps.lidar) return; // hide UI on non-LiDAR devices

// Component
<DimensioningView
  style={{ flex: 1 }}
  mode="offline"
  measurementUnit="centimeters"
  onCapture={m => console.log(m.length, m.width, m.height)}
  onError={e => console.warn(e.message)}
/>
```

Consumers must bump their app's iOS deployment target to **17.0** (the Dimensioning subspec requires ARKit / RealityKit).

## Verified

- ✅ iOS Debug build (iPhone 17 Pro Simulator) — `** BUILD SUCCEEDED **`
- ✅ Android library compile (via `example/android` gradle) — `BUILD SUCCESSFUL`
- ✅ `tsc --noEmit` clean
- ✅ `jest` 12/12 passing
- ✅ Pod install resolves cleanly from CocoaPods trunk (VisionSDK 2.3.0)


