### PR TITLE
feat: bump iOS VisionSDK to 2.3.1 → 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-sdk",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "VisionSDK for React Native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -46,9 +46,9 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
   # Core scanner + OCR
-  s.dependency "VisionSDK", "= 2.3.0"
+  s.dependency "VisionSDK", "= 2.3.1"
   # 3-D box measurement — brings MVDimensioningCore.xcframework, ARKit, RealityKit, PostHog
-  s.dependency "VisionSDK/Dimensioning", "= 2.3.0"
+  s.dependency "VisionSDK/Dimensioning", "= 2.3.1"
 
   # New Architecture dependencies
   install_modules_dependencies(s)


### PR DESCRIPTION
## Summary

Bumps the package to **3.2.0** and the iOS native SDK to **VisionSDK 2.3.1**, pulling in the Arista item-label extraction improvements.

## Changes

- `package.json`: `3.1.0` → `3.2.0` (feat-level bump)
- `react-native-vision-sdk.podspec`: `VisionSDK` + `VisionSDK/Dimensioning` pod pins `2.3.0` → `2.3.1`

## What's in vision-sdk-ios 2.3.1

- **Arista a-priori patterns**: carton/box ID (OCR-tolerant, incl. bare `ID: PAS…`) and quantity with OCR digit-letter normalization (`l/I→1`, `o/O→0`)
- **Field guards (KV + NER)**: drop `model_number` < 8 chars / label-words / parenthesized noise; drop `carton_id` < 6 chars
- **KV-priority for Arista quantity & origin country** — KV model is authoritative over NER when both produce values, applied in both local-models and remote-models schemes
- **Country mapping fix**: associated response maps the first *non-empty* country (empty placeholder at index 0 no longer drops origin country)
- Section detection threshold lowered `0.25` → `0.15` to recover under-detected sections

## Notes

- `example/ios/Podfile.lock` intentionally untouched — regenerates on next `pod install` / `yarn bootstrap`
- Android JitPack coordinate unchanged
- Typecheck clean, 12/12 tests pass
- Publish with `npm publish` / `release-it --no-increment` — version is already set in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)