### PR TITLE
chore: reset package.json to 3.1.0 (release-it owns versioning)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-sdk",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "description": "VisionSDK for React Native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   # all consumers. Splitting Dimensioning into a separate optional pod
   # (so non-LiDAR consumers can stay on iOS 16) is a follow-up.
   s.platforms    = { :ios => "17.0" }
-  s.source       = { :git => "https://github.com/packagex-io/react-native-vision-sdk.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/packagex-io/react-native-vision-sdk.git", :tag => "v#{s.version}" }
 
   # Explicitly set module name to ensure Swift bridging header matches
   s.module_name  = "react_native_vision_sdk"


### PR DESCRIPTION
Reverts the manual pre-bump to 3.2.0 from #182. 