### PR TITLE
VisionSDK 2.3.3 / android v2.4.52: landscape bounding boxes, ARGB colors, cloud image-load fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -155,7 +155,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 // From node_modules
-  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.51'
+  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.52'
   implementation 'com.github.asadullahilyas:HandyUtils:1.1.6'
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -155,7 +155,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 // From node_modules
-  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.48'
+  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.51'
   implementation 'com.github.asadullahilyas:HandyUtils:1.1.6'
 }
 

--- a/android/src/main/java/com/visionsdk/utils/VisionSdkExtensions.kt
+++ b/android/src/main/java/com/visionsdk/utils/VisionSdkExtensions.kt
@@ -79,14 +79,19 @@ fun uriToBitmap(context: Context, uri: Uri, onComplete: (Bitmap?) -> Unit) {
     // Handle local URIs (file://, content://, etc)
     else {
         try {
-            val inputStream = context.contentResolver.openInputStream(uri)
-            if (inputStream != null) {
-                val bitmap = BitmapFactory.decodeStream(inputStream)
-                inputStream.close()
-                onComplete(bitmap)
-            } else {
-                onComplete(null)
-            }
+            // A scheme-less path (e.g. "/data/.../cache/camera_*.jpg" from a capture) has no
+            // content provider, so ContentResolver.openInputStream throws FileNotFoundException
+            // ("No content provider"). Decode such bare/file paths directly via decodeFile
+            // (no stream to leak). content:// still goes through the resolver; use {} closes it.
+            val bitmap =
+                if (scheme == null || scheme == "file") {
+                    BitmapFactory.decodeFile(uri.path ?: uri.toString())
+                } else {
+                    context.contentResolver.openInputStream(uri)?.use {
+                        BitmapFactory.decodeStream(it)
+                    }
+                }
+            onComplete(bitmap)
         } catch (e: FileNotFoundException) {
             android.util.Log.e("VisionSDK", "File not found: ${uri}", e)
             onComplete(null)

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -55,11 +55,10 @@ end
 target 'VisionSdkExample' do
   config = use_native_modules!
 
-  # VisionSDK 2.3.2 (clean, non-nested VisionSDKDimensioning.xcframework) from
-  # CocoaPods trunk. Matches the deps declared by the react-native-vision-sdk
-  # podspec; pinned explicitly here for clarity.
-  pod 'VisionSDK', '= 2.3.2'
-  pod 'VisionSDK/Dimensioning', '= 2.3.2'
+  # VisionSDK from CocoaPods trunk. Matches the deps declared by the
+  # react-native-vision-sdk podspec; pinned explicitly here for clarity.
+  pod 'VisionSDK', '= 2.3.3'
+  pod 'VisionSDK/Dimensioning', '= 2.3.3'
 
   use_react_native!(
     :path => config[:reactNativePath],

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - PostHog (3.59.3)
+  - PostHog (3.60.1)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -1870,7 +1870,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-vision-sdk (3.1.0):
+  - react-native-vision-sdk (3.3.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1897,8 +1897,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-    - VisionSDK (= 2.3.2)
-    - VisionSDK/Dimensioning (= 2.3.2)
+    - VisionSDK (= 2.3.3)
+    - VisionSDK/Dimensioning (= 2.3.3)
     - Yoga
   - React-NativeModulesApple (0.82.1):
     - boost
@@ -2849,10 +2849,10 @@ PODS:
     - SocketRocket
     - Yoga
   - SocketRocket (0.7.1)
-  - VisionSDK (2.3.2):
-    - VisionSDK/Core (= 2.3.2)
-  - VisionSDK/Core (2.3.2)
-  - VisionSDK/Dimensioning (2.3.2):
+  - VisionSDK (2.3.3):
+    - VisionSDK/Core (= 2.3.3)
+  - VisionSDK/Core (2.3.3)
+  - VisionSDK/Dimensioning (2.3.3):
     - PostHog (~> 3.0)
     - VisionSDK/Core
   - Yoga (0.0.0)
@@ -2942,8 +2942,8 @@ DEPENDENCIES:
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - RNWorklets (from `../node_modules/react-native-worklets`)
   - SocketRocket (~> 0.7.1)
-  - VisionSDK (= 2.3.2)
-  - VisionSDK/Dimensioning (= 2.3.2)
+  - VisionSDK (= 2.3.3)
+  - VisionSDK/Dimensioning (= 2.3.3)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -3129,86 +3129,86 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  PostHog: 6c74cc84f3872f4335108ff363aecdeb7c278052
+  PostHog: 757f3500f59b8c02340444a52461350d938e42ea
   RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: f17e2ebc07876ca9ab8eb6e4b0a4e4647497ae3a
   RCTRequired: e2c574c1b45231f7efb0834936bd609d75072b63
   RCTTypeSafety: c693294e3993056955c3010eb1ebc574f1fcded6
   React: aeece948ccf155182ea86a2395786ed31cf21c61
   React-callinvoker: 05ad789505922d68c06cde1c8060e734df9fe182
-  React-Core: 727a48090292599bda380e05c9f1318e21578837
-  React-CoreModules: b26015efc6c222479e6939c0d7497cfac08a1a24
-  React-cxxreact: 1e6640d1e9a36744c4ce861bf2a5c8cee4abe9cf
+  React-Core: 956ac86b4d9b0c0fd9a14b9cc533aa297bb501c0
+  React-CoreModules: 3a8d39778cf9eeca40e419814e875da1a8e29855
+  React-cxxreact: db275765e1eb08f038599fb44114cf57ee0d18cd
   React-debug: 1dfa1d1cbd93bdaffa3b140190829f9fd9e27985
-  React-defaultsnativemodule: 5a7a0b2575032cd1ce8fac5d5e0611cf55d3bf2c
-  React-domnativemodule: 9e86dc9883b569f169e1e9da8c0e34292c469014
-  React-Fabric: bc78d9349f6385cb619e901911be752fb076730b
-  React-FabricComponents: 74412b4e4f29cfa8057edaf59fb3d7fc8d082b46
-  React-FabricImage: e5f1599f50d2c122c220744ed00ef1a271619938
-  React-featureflags: 773391abff0339af3697f8a987890191c122b320
-  React-featureflagsnativemodule: 4ffcace380a76af8982bdcf64ed29a02cea4fb75
-  React-graphics: 5d44b20c935d17bea4712edf5ce4834c4dead85d
-  React-hermes: 5c2453ae5a3c2f34a15eaefb229375998e365810
-  React-idlecallbacksnativemodule: e2b63f28f0b14a8ab01ba922b1611426b3999301
-  React-ImageManager: c50c501798a2bb89109db71ce74345bd9d6671d1
-  React-jserrorhandler: f773f1866064afd558506f9cd4cac19e6fcf9147
-  React-jsi: 389d2e9fe9bd935bdaff38e0d72eb2cad1ad3071
-  React-jsiexecutor: 0821fa7695e1a6a868aa47a40a0fc5036552128b
-  React-jsinspector: 9040cfa67dcaefbc856d8c79ab42e9be92736935
-  React-jsinspectorcdp: bf0403947b41a3fccab67cb11fd54f39a6d85351
-  React-jsinspectornetwork: f06ebe5a22316242b0f7b2b9514f03f3732306c5
-  React-jsinspectortracing: 6e22744e791cde5b4cd91343946dfa536f49f795
-  React-jsitooling: e9a0bab6a6ca8a0a5ee700d19e067bdb214eb5b5
-  React-jsitracing: af2ee8a89f5aa7495aae1f27edc422e00f5a6880
-  React-logger: fceaaedb9c715923a1900af68a7534e9b3a601a1
-  React-Mapbuffer: 7e7ca4c53288117e7e0406e9eaa804bf259b4b30
-  React-microtasksnativemodule: 885bebe5c5f25035e1fd0920776078840a0e3a76
-  react-native-safe-area-context: 54d812805f3c4e08a4580ad086cbde1d8780c2e4
-  react-native-vision-sdk: 54fb4ea04d0339e2dfb2e3c2866a73d2332bf7dd
-  React-NativeModulesApple: c4bee6aa736092cd347456488a4f97a8e7517604
+  React-defaultsnativemodule: 35f353ba06901fb5e374bc56e750fde05cbb05b9
+  React-domnativemodule: cf9e1b1b520ce0e66396c2744b3eb6d419711c13
+  React-Fabric: c0b0c1ad70476d354b3da9fef96094f7b37804da
+  React-FabricComponents: 8c6861c5233cf0d5685cee301a979313090e2f57
+  React-FabricImage: cef8883d2fb6c892003fefcad261d2898adbe926
+  React-featureflags: 0e2b969019c2b118de64a6d4c55ef7c05f2b0f1d
+  React-featureflagsnativemodule: e1ef619d14fe0a68d4783b32293309dbb13ef2a5
+  React-graphics: 0fc6b7acaff7161bda05bf8bffceacc2b0b4e38d
+  React-hermes: b454b9352bc26e638704d103009f659a125b86d3
+  React-idlecallbacksnativemodule: 35ab292f8404c469744db5a5dd5f0f27f95e5ebf
+  React-ImageManager: 3312c550ebcf6b7d911d9993082adcb3e1407ce8
+  React-jserrorhandler: 2a7f2d94566f05f8cb82288afd46bc0fd8b2ffc7
+  React-jsi: 7aa265cf8372d8385ccc7935729e76d27e694dfe
+  React-jsiexecutor: 8dd53bebfb3bc12f0541282aa4c858a433914e37
+  React-jsinspector: f89b9ae62a4e2f6035b452442ef20a7f98f9cb27
+  React-jsinspectorcdp: 44e46c1473a8deecf7b188389ed409be83fb3cc7
+  React-jsinspectornetwork: dc9524f6e3d7694b1b6f4bd22dedad8ccc2c0a80
+  React-jsinspectortracing: 0166ebbdfb125936a5d231895de3c11a19521dfc
+  React-jsitooling: 34692514ec8d8735938eda3677808a58f41c925b
+  React-jsitracing: a598dae84a87f8013635d09c5e7884023bda8501
+  React-logger: 500f2fa5697d224e63c33d913c8a4765319e19bf
+  React-Mapbuffer: 06d59c448da7e34eb05b3fb2189e12f6a30fec57
+  React-microtasksnativemodule: d1ee999dc9052e23f6488b730fa2d383a4ea40e5
+  react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
+  react-native-vision-sdk: 4158190f8eb61bba60773319ceb76b60043cf704
+  React-NativeModulesApple: 46690a0fe94ec28fc6fc686ec797b911d251ded0
   React-oscompat: 95875e81f5d4b3c7b2c888d5bd2c9d83450d8bdb
-  React-perflogger: d5b5677902d23a6611b700601634271b29356ac6
-  React-performancecdpmetrics: f20287f906b00a05070fce0bc400ea492991f13e
-  React-performancetimeline: c1f898134defda04623db379d57d9024d52ef63d
+  React-perflogger: 2e229bf33e42c094fd64516d89ec1187a2b79b5b
+  React-performancecdpmetrics: 05ba4bd83f36acf192071bb5d9c8f45faf04d140
+  React-performancetimeline: bfc96fcd2b79f7489dd54e3df4cba186dd8dd141
   React-RCTActionSheet: 2399bb6cc8adaef2e5850878102fea2ad1788a0e
-  React-RCTAnimation: a7e596bacb4706501556dcaaa8cd4062c8858d40
-  React-RCTAppDelegate: 40a84753dc9d7c2535b9e748c30bae50d39c6580
-  React-RCTBlob: e3264ae55b1b856db8e654bb7066b8343e030a67
-  React-RCTFabric: e5bf005693c6edd581657979624bd33db479b008
-  React-RCTFBReactNativeSpec: 3984efab208a7d570cb2a5a8b94921ff61189307
-  React-RCTImage: fb1d64345bb2e26af63e06e1ffc2cf99d572e2e1
-  React-RCTLinking: cb91127e75ee2d081f1abffd08d63db185805439
-  React-RCTNetwork: f38a98b030faedf2dc5c9061d6ed0074b3513c72
-  React-RCTRuntime: fb2eb8fd62a7b9b3e8a29ad0ecf000b453070cb0
-  React-RCTSettings: 00cc62efb88ec24608cefaa7db4ad04461a511b4
-  React-RCTText: 2b963648a99f49875349bd18c0dd7f2a4acf50c1
-  React-RCTVibration: 16e31c7f90f13bec10385aeb5cc61e8a45e591e4
+  React-RCTAnimation: d1deb6946e83e22a795a7d0148b94faad8851644
+  React-RCTAppDelegate: 10b35d5cec3f8653f6de843ae800b3ba8050b801
+  React-RCTBlob: 85150378edc42862d7c13ff2502693f32b174f91
+  React-RCTFabric: 736f9da3ad57e2cef5fa4c132999933a89bb8378
+  React-RCTFBReactNativeSpec: 705ec584758966950a31fa235539b57523059837
+  React-RCTImage: bb6cbdc22698b3afc8eb8d81ef03ee840d24c6f6
+  React-RCTLinking: e8b006d101c45651925de3e82189f03449eedfe7
+  React-RCTNetwork: 7999731af05ec8f591cbc6ad4e29d79e209c581a
+  React-RCTRuntime: 99d8a2a17747866fb972561cdb205afe9b26d369
+  React-RCTSettings: 839f334abb92e917bc24322036081ffe15c84086
+  React-RCTText: 272f60e9a5dbfd14c348c85881ee7d5c7749a67c
+  React-RCTVibration: 1ffa30a21e2227be3afe28d657ac8e6616c91bae
   React-rendererconsistency: 3c3e198aba0255524ed7126aa812d22ce750d217
-  React-renderercss: d07e645ab9f2b411513c9d3947ad627a1ef3bec7
-  React-rendererdebug: 79ba04c9662222da80b140e75550e050c0520630
-  React-RuntimeApple: ab93dc2863d621b085788dc3781d141fd4d410f7
-  React-RuntimeCore: 301320b1d544ba82e8edb8c5e57f245cbc8bb2c0
-  React-runtimeexecutor: aa09562cd04c048b4246ef3997806df0ce0e7ff2
-  React-RuntimeHermes: e5b85c57ffd7d2913b4c85e96e133428ac6cb46d
-  React-runtimescheduler: 15a7e3d5b5d18d2e4def7c7cd937be2085fe9245
-  React-timing: 5d765a145ac47783de0bf116d4dd9cfa0c498819
-  React-utils: a9abebe9dc25642955b5d2cec8c16bbf55a1bc52
-  React-webperformancenativemodule: 85dce57a9e73457a3686aee0d8e929518713fc05
-  ReactAppDependencyProvider: cc2795efe30a023c3a505676b9c748b664b9c0a1
-  ReactCodegen: 897bad2d2f722ff4dc46fc144f9cc018db0e2ce4
-  ReactCommon: c5803af00bd3737dc1631749b1f1da5beba5b049
-  RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
-  RNGestureHandler: 927ba2c590c8973f24624f1c1279be08a22ec58d
-  RNPermissions: 5db71b5544a9c5ab2a5f121c2310b9e5269f0080
-  RNReanimated: fe6e74170e4b5c5acdbe10cf8f6883e410ba80d3
-  RNScreens: 3693ec4bbc0065151b843269e50e9807644e9918
-  RNSVG: 16667e18ce40770c8c41a87f3133004c5cf4e09a
-  RNVectorIcons: 6acc19c833be864e9c70894e101a587fe491150a
-  RNWorklets: daa0a3e7946a9c4042f3a962c87a12dc5bc0badd
+  React-renderercss: 6b3ce3dfadf991937ae3229112be843ef1438c32
+  React-rendererdebug: baf9e1daa07ac7f9aca379555126d29f963ba38b
+  React-RuntimeApple: 4136aee89257894955ef09e9f9ef74f0c27596be
+  React-RuntimeCore: e9a743d7de4bbd741b16e10b26078d815d6513ab
+  React-runtimeexecutor: 781e292362066af82fa2478d95c6b0e374421844
+  React-RuntimeHermes: 6ab3c2847516769fc860d711814f1735859cad74
+  React-runtimescheduler: 824c83a5fd68b35396de6d4f2f9ae995daac861b
+  React-timing: 1ebc7102dd52a3edcc63534686bb156e12648411
+  React-utils: abf37b162f560cd0e3e5d037af30bb796512246d
+  React-webperformancenativemodule: 50a57c713a90d27ae3ab947a6c9c8859bcb49709
+  ReactAppDependencyProvider: a45ef34bb22dc1c9b2ac1f74167d9a28af961176
+  ReactCodegen: 878add6c7d8ff8cea87697c44d29c03b79b6f2d9
+  ReactCommon: 804dc80944fa90b86800b43c871742ec005ca424
+  RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
+  RNGestureHandler: e1cf8ef3f11045536eed6bd4f132b003ef5f9a5f
+  RNPermissions: ce40243858e8ad423729adbdbb3e51b25e00552b
+  RNReanimated: ac06da53579693ab451941ef89f5a55afeab0dd9
+  RNScreens: d821082c6dd1cb397cc0c98b026eeafaa68be479
+  RNSVG: 005860704c95493cd23a417dfbeb76dcd8bb7042
+  RNVectorIcons: 791f13226ec4a3fd13062eda9e892159f0981fae
+  RNWorklets: ab618bf7d1c7fd2cb793b9f0f39c3e29274b3ebf
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  VisionSDK: f21e8b8234e529b16479159f1cc3f4a0db90a3c2
+  VisionSDK: 3eacbdde5914358e704daa30352fa554c0fc6c1c
   Yoga: 689c8e04277f3ad631e60fe2a08e41d411daf8eb
 
-PODFILE CHECKSUM: 7dec3027ad7c3607a21c4ef3a86e7f670b455aed
+PODFILE CHECKSUM: f1c8bfac406a667c354624048afcd89fe33498fd
 
 COCOAPODS: 1.16.2

--- a/example/src/screens/ScannerScreen.tsx
+++ b/example/src/screens/ScannerScreen.tsx
@@ -1277,7 +1277,8 @@ export function ScannerScreen({ navigation }: Props) {
       shouldScanInFocusImageRect: false,
       showCodeBoundariesInMultipleScan: settings.multipleScan,
       documentBoundaryBorderColor: theme.colors.accent,
-      documentBoundaryFillColor: `${theme.colors.accent}4D`,
+      // Native parses 8-digit hex as ARGB (#AARRGGBB) — alpha must lead.
+      documentBoundaryFillColor: `#4D${theme.colors.accent.slice(1)}`,
     });
   }, [settings]);
 
@@ -1415,9 +1416,10 @@ export function ScannerScreen({ navigation }: Props) {
               isTemplateCreateMode ? theme.colors.success : theme.colors.accent
             }
             barcodeBoundingBoxFillColor={
+              // Native parses 8-digit hex as ARGB (#AARRGGBB), not RGBA — alpha must lead.
               isTemplateCreateMode
-                ? `${theme.colors.success}33`
-                : `${theme.colors.accent}2A`
+                ? `#33${theme.colors.success.slice(1)}`
+                : `#2A${theme.colors.accent.slice(1)}`
             }
             template={activeTemplate}
             onCapture={handleCapture}

--- a/ios/RNVisionCameraView.swift
+++ b/ios/RNVisionCameraView.swift
@@ -575,29 +575,15 @@ class RNVisionCameraView: UIView {
     cameraView.setFocusSettingsTo(focusSettings)
   }
 
-  /// Parses a hex color string (e.g., "#ff0000", "#ff000080") into a UIColor.
-  /// For 8-digit strings, the format is RRGGBBAA (alpha last).
+  /// Parses a hex color string into a UIColor. 8-digit strings are `#AARRGGBB`
+  /// (alpha first), matching Android's Color.parseColor and `parseARGBColor` below.
+  ///
+  /// Previously this used RRGGBBAA (alpha last), which disagreed with both Android
+  /// and the barcode-bbox color path (`parseARGBColor`) — the same `#AARRGGBB`
+  /// string rendered differently per platform/field. Unified on `#AARRGGBB` so one
+  /// format is correct everywhere; this delegates to the single implementation.
   private static func parseColor(_ hex: String?) -> UIColor? {
-    guard let hex = hex else { return nil }
-    let cleanHex = hex.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "#", with: "")
-
-    var hexValue: UInt64 = 0
-    let scanner = Scanner(string: cleanHex)
-    guard scanner.scanHexInt64(&hexValue) else { return nil }
-
-    if cleanHex.count == 6 {
-      let r = CGFloat((hexValue & 0xFF0000) >> 16) / 255.0
-      let g = CGFloat((hexValue & 0x00FF00) >> 8) / 255.0
-      let b = CGFloat(hexValue & 0x0000FF) / 255.0
-      return UIColor(red: r, green: g, blue: b, alpha: 1.0)
-    } else if cleanHex.count == 8 {
-      let r = CGFloat((hexValue & 0xFF000000) >> 24) / 255.0
-      let g = CGFloat((hexValue & 0x00FF0000) >> 16) / 255.0
-      let b = CGFloat((hexValue & 0x0000FF00) >> 8) / 255.0
-      let a = CGFloat(hexValue & 0x000000FF) / 255.0
-      return UIColor(red: r, green: g, blue: b, alpha: a)
-    }
-    return nil
+    return parseARGBColor(hex)
   }
 
   /// Parses a hex color string in Android AARRGGBB format (e.g., "#8B5CF6", "#338B5CF6") into a UIColor.

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -45,9 +45,9 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
   # Core scanner + OCR
-  s.dependency "VisionSDK", "= 2.3.2"
+  s.dependency "VisionSDK", "= 2.3.3"
   # 3-D box measurement — brings MVDimensioningCore.xcframework, ARKit, RealityKit, PostHog
-  s.dependency "VisionSDK/Dimensioning", "= 2.3.2"
+  s.dependency "VisionSDK/Dimensioning", "= 2.3.3"
 
   # New Architecture dependencies
   install_modules_dependencies(s)

--- a/src/VisionCameraTypes.ts
+++ b/src/VisionCameraTypes.ts
@@ -405,11 +405,17 @@ export interface VisionCameraViewProps {
    */
   showCodeBoundingBoxes?: boolean;
 
-  /** Hex color for the native overlay border (default `#8B5CF6`). Only used when `showCodeBoundingBoxes=true`. */
+  /**
+   * Hex color for the native overlay border (default `#8B5CF6`). Only used when `showCodeBoundingBoxes=true`.
+   *
+   * Color format: `#RRGGBB` or, for alpha, **`#AARRGGBB` (alpha first)** — NOT the
+   * CSS `#RRGGBBAA` convention. Both native parsers (iOS + Android) read the leading
+   * byte as alpha, so e.g. 20%-opacity yellow is `#33FFD60A`, not `#FFD60A33`.
+   */
   barcodeBoundingBoxBorderColor?: string;
   /** Native overlay border width in dp (default 3). Only used when `showCodeBoundingBoxes=true`. */
   barcodeBoundingBoxBorderWidth?: number;
-  /** Hex color (with optional alpha) for the native overlay fill (default `#338B5CF6` = purple @ 20%). Only used when `showCodeBoundingBoxes=true`. */
+  /** Fill color for the native overlay (default `#338B5CF6` = purple @ 20%). Use `#AARRGGBB` (alpha first) for alpha — see `barcodeBoundingBoxBorderColor`. Only used when `showCodeBoundingBoxes=true`. */
   barcodeBoundingBoxFillColor?: string;
 
   /**
@@ -745,11 +751,17 @@ export interface VisionCameraProps {
    */
   showCodeBoundingBoxes?: boolean;
 
-  /** Hex color for the native overlay border (default `#8B5CF6`). Only used when `showCodeBoundingBoxes=true`. */
+  /**
+   * Hex color for the native overlay border (default `#8B5CF6`). Only used when `showCodeBoundingBoxes=true`.
+   *
+   * Color format: `#RRGGBB` or, for alpha, **`#AARRGGBB` (alpha first)** — NOT the
+   * CSS `#RRGGBBAA` convention. Both native parsers (iOS + Android) read the leading
+   * byte as alpha, so e.g. 20%-opacity yellow is `#33FFD60A`, not `#FFD60A33`.
+   */
   barcodeBoundingBoxBorderColor?: string;
   /** Native overlay border width in dp (default 3). Only used when `showCodeBoundingBoxes=true`. */
   barcodeBoundingBoxBorderWidth?: number;
-  /** Hex color (with optional alpha) for the native overlay fill (default `#338B5CF6` = purple @ 20%). Only used when `showCodeBoundingBoxes=true`. */
+  /** Fill color for the native overlay (default `#338B5CF6` = purple @ 20%). Use `#AARRGGBB` (alpha first) for alpha — see `barcodeBoundingBoxBorderColor`. Only used when `showCodeBoundingBoxes=true`. */
   barcodeBoundingBoxFillColor?: string;
 
   /**

--- a/src/VisionCameraTypes.ts
+++ b/src/VisionCameraTypes.ts
@@ -565,8 +565,9 @@ export interface FocusSettings {
   /**
    * @optional
    * @type {string}
-   * @description Fill color for valid code boundaries (hex color string with optional alpha, e.g., '#2abd5140').
-   * @default '#00ff004D'
+   * @description Fill color for valid code boundaries. 8-digit hex is `#AARRGGBB` (alpha first),
+   *   NOT CSS `#RRGGBBAA` — e.g. green @ 30% is '#4D00ff00'. `#RRGGBBAA` is not supported.
+   * @default '#4D00ff00'
    */
   validCodeBoundaryFillColor?: string;
 
@@ -589,8 +590,9 @@ export interface FocusSettings {
   /**
    * @optional
    * @type {string}
-   * @description Fill color for invalid code boundaries (hex color string with optional alpha, e.g., '#cc082940').
-   * @default '#ff00004D'
+   * @description Fill color for invalid code boundaries. 8-digit hex is `#AARRGGBB` (alpha first),
+   *   NOT CSS `#RRGGBBAA` — e.g. red @ 30% is '#4Dff0000'. `#RRGGBBAA` is not supported.
+   * @default '#4Dff0000'
    */
   inValidCodeBoundaryFillColor?: string;
 
@@ -613,8 +615,9 @@ export interface FocusSettings {
   /**
    * @optional
    * @type {string}
-   * @description Fill color for document boundaries (hex color string with optional alpha, e.g., '#e3000080').
-   * @default '#0000ff4D'
+   * @description Fill color for document boundaries. 8-digit hex is `#AARRGGBB` (alpha first),
+   *   NOT CSS `#RRGGBBAA` — e.g. blue @ 30% is '#4D0000ff'. `#RRGGBBAA` is not supported.
+   * @default '#4D0000ff'
    */
   documentBoundaryFillColor?: string;
 


### PR DESCRIPTION
Bumps the native SDKs and lands the fixes verified on-device this cycle.

## Native bumps
- `vision-sdk-android` → **v2.4.52** (JitPack)
- `VisionSDK` pod → **2.3.3** (CocoaPods trunk) — podspec + example Podfile

## Fixes
- **Landscape bounding boxes** (from the native bumps): live-overlay + capture `normalizedBoundingBox` now track the preview orientation; boxes land on the barcode in portrait and both landscapes. Verified on-device (iOS + Android).
- **Bounding-box colors**: the example built fill colors as RGBA (`#RRGGBBAA`), but the native parsers read 8-digit hex as **ARGB** (`#AARRGGBB`), so fill rendered opaque red. Fixed the example to lead with alpha, unified the iOS wrapper's two color parsers onto `#AARRGGBB`, and documented the format on the props.
- **Cloud OCR image load** (`uriToBitmap`): a captured image passed as a bare filesystem path (`/data/.../cache/camera_*.jpg`) threw `FileNotFoundException("No content provider")` because `ContentResolver.openInputStream` has no provider for a scheme-less path. Now decode `null`/`file` scheme paths via `BitmapFactory.decodeFile`; `content://` still routes through the resolver. Runtime-confirmed on device.

## Validation
- `tsc --noEmit`, `eslint`, `jest` (12/12) all green.
- Both native artifacts are published and consumable (JitPack v2.4.52, CocoaPods 2.3.3).

