### PR TITLE
chore: bump version to 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-sdk",
-  "version": "3.3.0",
+  "version": "3.5.0",
   "description": "VisionSDK for React Native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Bumps `react-native-vision-sdk` from 3.3.0 to 3.5.0.

