### PR TITLE
fix(ios): normalize zoom so 1.0 always maps to primary wide camera

### DIFF
--- a/ios/RNVisionCameraView.swift
+++ b/ios/RNVisionCameraView.swift
@@ -647,9 +647,9 @@ class RNVisionCameraView: UIView {
     var zoomValue = CGFloat(zoomLevel.floatValue)
 
     // Normalize so zoomLevel 1.0 = primary (wide) camera on all devices.
-    // On virtual multi-lens devices the first switchover factor is where the wide
-    // lens starts (e.g. 2.0 on iPhone Pro); single-lens devices return empty array.
-    if let wideZoom = videoDevice.virtualDeviceSwitchOverVideoZoomFactors.first {
+    // On virtual devices that start at ultra-wide, the first switchover factor marks where wide starts.
+    if videoDevice.constituentDevices.first?.deviceType == .builtInUltraWideCamera,
+       let wideZoom = videoDevice.virtualDeviceSwitchOverVideoZoomFactors.first {
       zoomValue *= CGFloat(truncating: wideZoom)
     }
 

--- a/ios/RNVisionCameraView.swift
+++ b/ios/RNVisionCameraView.swift
@@ -301,6 +301,7 @@ class RNVisionCameraView: UIView {
 
     // Re-apply props that may have been set before this recreation
     applyCodeBoundingBoxSettings()
+    updateZoom()
 
     // Ensure frame is correct
     cameraView?.frame = self.bounds
@@ -459,6 +460,7 @@ class RNVisionCameraView: UIView {
     // Update actual state based on what operation completed
     if actualCameraState == .starting {
       actualCameraState = success ? .running : .stopped
+      if success { updateZoom() }
     } else if actualCameraState == .stopping {
       actualCameraState = .stopped
     }
@@ -641,19 +643,21 @@ class RNVisionCameraView: UIView {
   
   private func updateZoom() {
     guard let videoDevice = try? cameraView?.videoDevice else { return }
-    
-    var zoomValue = zoomLevel.floatValue
-    
+
+    var zoomValue = CGFloat(zoomLevel.floatValue)
+
+    // Normalize so zoomLevel 1.0 = primary (wide) camera on all devices.
+    // On virtual multi-lens devices the first switchover factor is where the wide
+    // lens starts (e.g. 2.0 on iPhone Pro); single-lens devices return empty array.
+    if let wideZoom = videoDevice.virtualDeviceSwitchOverVideoZoomFactors.first {
+      zoomValue *= CGFloat(truncating: wideZoom)
+    }
+
     DispatchQueue.main.async {
       try? videoDevice.lockForConfiguration()
-      
-      if CGFloat(zoomValue) < videoDevice.minAvailableVideoZoomFactor {
-        zoomValue = Float(videoDevice.minAvailableVideoZoomFactor)
-      } else if CGFloat(zoomValue) > videoDevice.maxAvailableVideoZoomFactor {
-        zoomValue = Float(videoDevice.maxAvailableVideoZoomFactor)
-      }
-      
-      videoDevice.videoZoomFactor = CGFloat(zoomValue)
+      zoomValue = min(max(zoomValue, videoDevice.minAvailableVideoZoomFactor),
+                      videoDevice.maxAvailableVideoZoomFactor)
+      videoDevice.videoZoomFactor = zoomValue
       videoDevice.unlockForConfiguration()
     }
   }

--- a/ios/RNVisionCameraView.swift
+++ b/ios/RNVisionCameraView.swift
@@ -654,11 +654,13 @@ class RNVisionCameraView: UIView {
     }
 
     DispatchQueue.main.async {
-      try? videoDevice.lockForConfiguration()
-      zoomValue = min(max(zoomValue, videoDevice.minAvailableVideoZoomFactor),
-                      videoDevice.maxAvailableVideoZoomFactor)
-      videoDevice.videoZoomFactor = zoomValue
-      videoDevice.unlockForConfiguration()
+      do {
+        try videoDevice.lockForConfiguration()
+        defer { videoDevice.unlockForConfiguration() }
+        zoomValue = min(max(zoomValue, videoDevice.minAvailableVideoZoomFactor),
+                        videoDevice.maxAvailableVideoZoomFactor)
+        videoDevice.videoZoomFactor = zoomValue
+      } catch {}
     }
   }
   

--- a/ios/RNVisionCameraView.swift
+++ b/ios/RNVisionCameraView.swift
@@ -660,7 +660,9 @@ class RNVisionCameraView: UIView {
         zoomValue = min(max(zoomValue, videoDevice.minAvailableVideoZoomFactor),
                         videoDevice.maxAvailableVideoZoomFactor)
         videoDevice.videoZoomFactor = zoomValue
-      } catch {}
+      } catch {
+        print("[RNVisionCameraView] Error setting zoom: \(error)")
+      }
     }
   }
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-sdk",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "VisionSDK for React Native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary

- `zoomLevel={1}` was mapping to `videoZoomFactor = 1.0` which is ultrawide on virtual multi-lens devices (iPhone Pro). Now multiplies by `virtualDeviceSwitchOverVideoZoomFactors.first` so `1.0` always = primary wide camera on any device.


## Zoom scale (after fix)

| `zoomLevel` | Result |
|---|---|
| `0.5` | Ultrawide |
| `1.0` | Primary wide (default) |
| `2.0` | 2x |
| `3.0` | 3x telephoto (Pro only) |

Single-lens devices clamp `0.5` up to `1.0` automatically.