### PR TITLE
feat: detection-config gating fix + pauseDetection()/resumeDetection() API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ package-lock.json
 
 # npm pack output
 *.tgz
+
+.worktrees/

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -155,7 +155,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 // From node_modules
-  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.54'
+  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.55'
   implementation 'com.github.asadullahilyas:HandyUtils:1.1.6'
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -155,7 +155,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 // From node_modules
-  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.53'
+  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.54'
   implementation 'com.github.asadullahilyas:HandyUtils:1.1.6'
 }
 

--- a/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
+++ b/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
@@ -473,6 +473,8 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
                 val settingsJson = args?.getString(0) ?: "{}"
                 setFocusSettings(root, settingsJson)
             }
+            "pauseDetection" -> pauseDetection(root)
+            "resumeDetection" -> resumeDetection(root)
             else -> Log.w(TAG, "Unknown command: $commandId")
         }
     }
@@ -520,6 +522,16 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
     override fun setZoom(view: VisionCameraView, level: Float) {
         Log.d(TAG, "setZoom called with level: $level")
         view.setZoomRatio(level)
+    }
+
+    override fun pauseDetection(view: VisionCameraView) {
+        Log.d(TAG, "pauseDetection called")
+        view.pauseDetection()
+    }
+
+    override fun resumeDetection(view: VisionCameraView) {
+        Log.d(TAG, "resumeDetection called")
+        view.resumeDetection()
     }
 
     private fun parseColor(hex: String?, default: Int): Int {

--- a/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
+++ b/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
@@ -421,6 +421,7 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
                             obj.optBoolean("qrcode", false) ||
                             obj.optBoolean("qrCode", false),
                     isDocumentIndicationOn = obj.optBoolean("document", false),
+                    isImageSharpnessIndicationOn = obj.optBoolean("sharpness", false),
                 ),
             )
         } catch (e: Exception) {

--- a/example/ios/VisionSdkExample/Info.plist
+++ b/example/ios/VisionSdkExample/Info.plist
@@ -53,9 +53,17 @@
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
-		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>

--- a/example/src/screens/ScannerScreen.tsx
+++ b/example/src/screens/ScannerScreen.tsx
@@ -897,6 +897,9 @@ export function ScannerScreen({ navigation }: Props) {
       // showing "disabled" while detection is actually running again
       // (mirrors MainActivity.kt / BarcodeViewController.swift demo behavior).
       setDetectionEnabled(true);
+      // Boxes from the old mode are stale the instant the scanner rebuilds —
+      // nothing repaints them until a fresh detection fires in the new mode.
+      setLiveBoundingBoxes([]);
       if (settings) {
         const updated = { ...settings, scanMode: mode, autoCapture: false };
         setSettings(updated);
@@ -1332,6 +1335,10 @@ export function ScannerScreen({ navigation }: Props) {
       cameraRef.current?.resumeDetection();
     } else {
       cameraRef.current?.pauseDetection();
+      // Pausing stops native emission entirely, so nothing will arrive to
+      // clear these — without this they'd stay frozen on screen until the
+      // next real detection after resume.
+      setLiveBoundingBoxes([]);
     }
   }, []);
 
@@ -1463,6 +1470,7 @@ export function ScannerScreen({ navigation }: Props) {
               document: true,
               documentConfidence: 0.8,
               documentCaptureDelay: settings.documentAutoCapture ? 3.0 : 9999,
+              sharpness: true,
             }}
             frameSkip={frameSkip}
           />

--- a/example/src/screens/ScannerScreen.tsx
+++ b/example/src/screens/ScannerScreen.tsx
@@ -55,6 +55,7 @@ import type {
   VisionCameraSharpnessScoreEvent,
   VisionCameraBarcodeDetectedEvent,
   VisionCameraBoundingBoxesUpdateEvent,
+  VisionCameraDetectedCodeBoundingBox,
 } from '../../../src/VisionCameraTypes';
 import { VisionCore } from '../../../src';
 import { SettingsModal } from './SettingsModal';
@@ -735,6 +736,10 @@ export function ScannerScreen({ navigation }: Props) {
   const cbFpsLastTickTime = useRef(0);
   // Tracks the bounding-box code count for the chip label.
   const cbFpsCodeCount = useRef(0);
+  // Live boxes drawn by the JS overlay (callback-driven, not the native BarcodeOverlayView).
+  const [liveBoundingBoxes, setLiveBoundingBoxes] = useState<
+    VisionCameraDetectedCodeBoundingBox[]
+  >([]);
 
   // Recognition indicators
   const [recognition, setRecognition] = useState({
@@ -987,18 +992,28 @@ export function ScannerScreen({ navigation }: Props) {
   );
 
   // onBoundingBoxesUpdate fires only when codes are in frame (not per processed
-  // frame). Used here only to update the code count label — not as a tick source.
+  // frame). Drives the code count label and the JS-rendered box overlay below —
+  // `boundingBox` is already in the VisionCamera view's own point/dp space (native
+  // handles device-rotation there), so no orientation math is needed here.
   const handleBoundingBoxesUpdate = useCallback(
     (e: VisionCameraBoundingBoxesUpdateEvent) => {
-      cbFpsCodeCount.current =
-        (e.barcodeBoundingBoxes?.length ?? 0) +
-        (e.qrCodeBoundingBoxes?.length ?? 0);
+      const boxes = [
+        ...(e.barcodeBoundingBoxes ?? []),
+        ...(e.qrCodeBoundingBoxes ?? []),
+      ];
+      cbFpsCodeCount.current = boxes.length;
+      setLiveBoundingBoxes(boxes.filter((b) => b.boundingBox));
     },
     []
   );
 
   const handleCapture = useCallback(
     async (e: VisionCameraCaptureEvent) => {
+      // Clear stale boxes immediately: they're positioned for whatever orientation
+      // was active before this capture, and nothing repaints them while the result
+      // screen is up. Without this, rotating the device during review and coming
+      // back shows the old, now-mismatched rectangles until a fresh detection fires.
+      setLiveBoundingBoxes([]);
       const imagePath = e.image ?? '';
       const barcodeData: BarcodeResultItem[] = (e.barcodes ?? []).map((b) => ({
         scannedCode: b.scannedCode,
@@ -1412,16 +1427,6 @@ export function ScannerScreen({ navigation }: Props) {
             scanMode={effectiveScanMode}
             autoCapture={autoCapture}
             cameraFacing={cameraFacing}
-            showCodeBoundingBoxes
-            barcodeBoundingBoxBorderColor={
-              isTemplateCreateMode ? theme.colors.success : theme.colors.accent
-            }
-            barcodeBoundingBoxFillColor={
-              // Native parses 8-digit hex as ARGB (#AARRGGBB), not RGBA — alpha must lead.
-              isTemplateCreateMode
-                ? `#33${theme.colors.success.slice(1)}`
-                : `#2A${theme.colors.accent.slice(1)}`
-            }
             template={activeTemplate}
             onCapture={handleCapture}
             onError={(err) => {
@@ -1441,7 +1446,35 @@ export function ScannerScreen({ navigation }: Props) {
             }}
             frameSkip={frameSkip}
           />
-        ) : (
+        ) : null}
+
+        {/* ── JS-rendered bounding boxes (callback-driven, native overlay disabled) ── */}
+        {hasPermission && liveBoundingBoxes.length > 0 && (
+          <View style={StyleSheet.absoluteFill} pointerEvents="none">
+            {liveBoundingBoxes.map((b, i) => (
+              <View
+                key={`${b.scannedCode}-${i}`}
+                style={[
+                  styles.jsBoundingBox,
+                  {
+                    left: b.boundingBox.x,
+                    top: b.boundingBox.y,
+                    width: b.boundingBox.width,
+                    height: b.boundingBox.height,
+                    borderColor: isTemplateCreateMode
+                      ? theme.colors.success
+                      : theme.colors.accent,
+                    backgroundColor: isTemplateCreateMode
+                      ? `${theme.colors.success}33`
+                      : `${theme.colors.accent}2A`,
+                  },
+                ]}
+              />
+            ))}
+          </View>
+        )}
+
+        {!hasPermission && (
           <View style={styles.noPerm}>
             <MCIcon name="camera-off" size={48} color={theme.colors.textMuted} />
             <Text style={styles.noPermText}>Camera permission required</Text>
@@ -1477,8 +1510,22 @@ export function ScannerScreen({ navigation }: Props) {
             <Text style={styles.fpsSuffix}> fps</Text>
           </View>
 
-          {/* Right: sound icon (position absolute) */}
+          {/* Right: sharpness readout (OCR/Photo only — that's the only pipeline
+              the native SDK computes it for) + sound icon (position absolute) */}
           <View style={styles.topRight} pointerEvents="box-none">
+            {scanMode === 'ocr' || scanMode === 'photo' ? (
+              <View style={styles.sharpnessChip} pointerEvents="none">
+                <Text
+                  style={[
+                    styles.fpsText,
+                    { color: sharpness >= SHARPNESS_THRESHOLD ? '#4ADE80' : '#FCA5A5' },
+                  ]}
+                >
+                  {sharpness.toFixed(2)}
+                </Text>
+                <Text style={styles.fpsSuffix}> shrp</Text>
+              </View>
+            ) : null}
             <TouchableOpacity
               style={styles.iconPill}
               onPress={cycleSoundMode}
@@ -2052,6 +2099,11 @@ const styles = StyleSheet.create({
     position: 'relative',
     backgroundColor: theme.colors.bgDeep,
   },
+  jsBoundingBox: {
+    position: 'absolute',
+    borderWidth: 3,
+    borderRadius: 4,
+  },
   noPerm: {
     flex: 1,
     justifyContent: 'center',
@@ -2121,6 +2173,16 @@ const styles = StyleSheet.create({
     color: '#4ADE80',
     fontSize: 9,
     opacity: 0.7,
+  },
+  // Same visual language as fpsChip, but laid out inline (topRight is a flex
+  // row) rather than absolute-positioned against topStrip.
+  sharpnessChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    borderRadius: theme.radii.sm,
+    paddingHorizontal: 7,
+    paddingVertical: 4,
   },
   modePill: {
     flexDirection: 'row',

--- a/example/src/screens/ScannerScreen.tsx
+++ b/example/src/screens/ScannerScreen.tsx
@@ -35,6 +35,7 @@ import {
   Platform,
   ScrollView,
   StyleSheet,
+  Switch,
   Text,
   TextInput,
   TouchableOpacity,
@@ -721,6 +722,7 @@ export function ScannerScreen({ navigation }: Props) {
   // Scanning state
   const [scanMode, setScanMode] = useState<VisionCameraScanMode>('barcode');
   const [autoCapture, setAutoCapture] = useState(false);
+  const [detectionEnabled, setDetectionEnabled] = useState(true);
   const [flashEnabled, setFlashEnabled] = useState(false);
   const [cameraFacing, setCameraFacing] = useState<'back' | 'front'>('back');
   const [zoomLevel, setZoomLevel] = useState(DEFAULT_ZOOM);
@@ -885,6 +887,11 @@ export function ScannerScreen({ navigation }: Props) {
       setScanMode(mode);
       setAutoCapture(false);
       setZoomLevel(DEFAULT_ZOOM);
+      // Switching scan mode tears down and rebuilds the native scanner, which
+      // always starts unpaused — resync the toggle so it doesn't keep
+      // showing "disabled" while detection is actually running again
+      // (mirrors MainActivity.kt / BarcodeViewController.swift demo behavior).
+      setDetectionEnabled(true);
       if (settings) {
         const updated = { ...settings, scanMode: mode, autoCapture: false };
         setSettings(updated);
@@ -1301,6 +1308,19 @@ export function ScannerScreen({ navigation }: Props) {
   }, [flashEnabled]);
 
   // ---------------------------------------------------------------------------
+  // Detection enabled toggle — pauses/resumes per-frame detection while the
+  // camera session/preview keeps running (see VisionCameraRefProps.pauseDetection).
+  // ---------------------------------------------------------------------------
+  const handleDetectionToggle = useCallback((enabled: boolean) => {
+    setDetectionEnabled(enabled);
+    if (enabled) {
+      cameraRef.current?.resumeDetection();
+    } else {
+      cameraRef.current?.pauseDetection();
+    }
+  }, []);
+
+  // ---------------------------------------------------------------------------
   // Sound mode cycle
   // ---------------------------------------------------------------------------
   const cycleSoundMode = useCallback(() => {
@@ -1581,6 +1601,22 @@ export function ScannerScreen({ navigation }: Props) {
                 </TouchableOpacity>
               ) : null}
             </TouchableOpacity>
+          </View>
+        ) : null}
+
+        {/* ── DETECTION ENABLED TOGGLE — left edge, below top strip ── */}
+        {!isTemplateCreateMode ? (
+          <View style={[styles.detectionToggleRow, { top: topInset + 44 }]} pointerEvents="box-none">
+            <View style={styles.detectionTogglePill}>
+              <Text style={styles.detectionToggleLabel}>Detection Enabled</Text>
+              <Switch
+                value={detectionEnabled}
+                onValueChange={handleDetectionToggle}
+                trackColor={{ false: theme.colors.indicatorOff, true: theme.colors.accent }}
+                thumbColor={detectionEnabled ? theme.colors.textOnAccent : '#5A5A5E'}
+                style={styles.detectionToggleSwitch}
+              />
+            </View>
           </View>
         ) : null}
 
@@ -2250,6 +2286,32 @@ const styles = StyleSheet.create({
   templateChipTextActive: {
     color: theme.colors.textOnAccent,
     fontWeight: theme.fontWeight.bold,
+  },
+
+  // ── Detection enabled toggle — left edge, below top strip ──────────────────
+  detectionToggleRow: {
+    position: 'absolute',
+    left: 12,
+    zIndex: 20,
+  },
+  detectionTogglePill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: theme.colors.bgFrosted,
+    borderRadius: theme.radii.circle,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderWidth: 1,
+    borderColor: theme.colors.btnCircleBorder,
+  },
+  detectionToggleLabel: {
+    color: theme.colors.textSecondary,
+    fontSize: theme.fontSize.xxs,
+    fontWeight: theme.fontWeight.semibold,
+    marginRight: 6,
+  },
+  detectionToggleSwitch: {
+    transform: [{ scale: 0.8 }],
   },
 
   // ── On-device hint ─────────────────────────────────────────────────────────

--- a/ios/DimensioningModule.swift
+++ b/ios/DimensioningModule.swift
@@ -1,6 +1,5 @@
 import Foundation
 import VisionSDK
-import VisionSDKDimensioning
 
 // MARK: - DimensioningModule
 //

--- a/ios/Fabric/VisionCameraViewComponentView.mm
+++ b/ios/Fabric/VisionCameraViewComponentView.mm
@@ -329,8 +329,8 @@ using namespace facebook::react;
 
   if (commandId != nil) {
     // Map command IDs to command names based on the order in supportedCommands array
-    // From VisionCameraViewNativeComponent.ts: ['capture', 'stop', 'start', 'rescan', 'toggleFlash', 'setZoom', 'setFocusSettings']
-    NSArray *commandNames = @[@"capture", @"stop", @"start", @"rescan", @"toggleFlash", @"setZoom", @"setFocusSettings"];
+    // From VisionCameraViewNativeComponent.ts: ['capture', 'stop', 'start', 'rescan', 'toggleFlash', 'setZoom', 'setFocusSettings', 'pauseDetection', 'resumeDetection']
+    NSArray *commandNames = @[@"capture", @"stop", @"start", @"rescan", @"toggleFlash", @"setZoom", @"setFocusSettings", @"pauseDetection", @"resumeDetection"];
 
     NSInteger cmdId = [commandId integerValue];
     if (cmdId >= 0 && cmdId < commandNames.count) {
@@ -367,6 +367,20 @@ using namespace facebook::react;
 {
   if ([_visionCameraView respondsToSelector:@selector(rescan)]) {
     [_visionCameraView performSelector:@selector(rescan)];
+  }
+}
+
+- (void)pauseDetection
+{
+  if ([_visionCameraView respondsToSelector:@selector(pauseDetection)]) {
+    [_visionCameraView performSelector:@selector(pauseDetection)];
+  }
+}
+
+- (void)resumeDetection
+{
+  if ([_visionCameraView respondsToSelector:@selector(resumeDetection)]) {
+    [_visionCameraView performSelector:@selector(resumeDetection)];
   }
 }
 

--- a/ios/Fabric/VisionCameraViewComponentView.mm
+++ b/ios/Fabric/VisionCameraViewComponentView.mm
@@ -335,7 +335,6 @@ using namespace facebook::react;
     NSInteger cmdId = [commandId integerValue];
     if (cmdId >= 0 && cmdId < commandNames.count) {
       actualCommandName = commandNames[cmdId];
-      NSLog(@"[VisionCameraViewComponentView] Mapped command ID %ld to '%@'", (long)cmdId, actualCommandName);
     }
   }
 

--- a/ios/RNDimensioningView.swift
+++ b/ios/RNDimensioningView.swift
@@ -1,6 +1,5 @@
 import UIKit
 import VisionSDK
-import VisionSDKDimensioning
 
 // MARK: - RNDimensioningView
 //

--- a/ios/RNVisionCameraView.swift
+++ b/ios/RNVisionCameraView.swift
@@ -698,9 +698,9 @@ class RNVisionCameraView: UIView {
     guard let cameraView = cameraView, let config = detectionConfig else { return }
 
     let detectionSettings = VisionSDK.CodeScannerView.ObjectDetectionConfiguration()
-    detectionSettings.isTextIndicationOn = config["text"] as? Bool ?? true
-    detectionSettings.isBarCodeOrQRCodeIndicationOn = config["barcode"] as? Bool ?? true
-    detectionSettings.isDocumentIndicationOn = config["document"] as? Bool ?? true
+    detectionSettings.isTextIndicationOn = config["text"] as? Bool ?? false
+    detectionSettings.isBarCodeOrQRCodeIndicationOn = config["barcode"] as? Bool ?? false
+    detectionSettings.isDocumentIndicationOn = config["document"] as? Bool ?? false
     detectionSettings.codeDetectionConfidence = config["barcodeConfidence"] as? Float ?? 0.5
     detectionSettings.documentDetectionConfidence = config["documentConfidence"] as? Float ?? 0.5
     detectionSettings.secondsToWaitBeforeDocumentCapture = config["documentCaptureDelay"] as? Double ?? 2.0
@@ -714,9 +714,9 @@ class RNVisionCameraView: UIView {
 
     // Apply existing detection config settings first
     if let config = detectionConfig {
-      detectionSettings.isTextIndicationOn = config["text"] as? Bool ?? true
-      detectionSettings.isBarCodeOrQRCodeIndicationOn = config["barcode"] as? Bool ?? true
-      detectionSettings.isDocumentIndicationOn = config["document"] as? Bool ?? true
+      detectionSettings.isTextIndicationOn = config["text"] as? Bool ?? false
+      detectionSettings.isBarCodeOrQRCodeIndicationOn = config["barcode"] as? Bool ?? false
+      detectionSettings.isDocumentIndicationOn = config["document"] as? Bool ?? false
       detectionSettings.codeDetectionConfidence = config["barcodeConfidence"] as? Float ?? 0.5
       detectionSettings.documentDetectionConfidence = config["documentConfidence"] as? Float ?? 0.5
       detectionSettings.secondsToWaitBeforeDocumentCapture = config["documentCaptureDelay"] as? Double ?? 2.0

--- a/ios/RNVisionCameraView.swift
+++ b/ios/RNVisionCameraView.swift
@@ -486,6 +486,19 @@ class RNVisionCameraView: UIView {
     cameraView?.rescan()
   }
 
+  /// Mode-agnostic universal pause: stops per-frame detection analysis while
+  /// keeping the camera session/preview alive. See CodeScannerView.pauseDetection()
+  /// (vision-sdk-ios). Does not affect capture()/manual capturePhoto() calls.
+  @objc func pauseDetection() {
+    cameraView?.pauseDetection()
+  }
+
+  /// Resumes detection after a pauseDetection() call. See
+  /// CodeScannerView.resumeDetection() (vision-sdk-ios).
+  @objc func resumeDetection() {
+    cameraView?.resumeDetection()
+  }
+
   @objc func toggleFlash(enabled: Bool) {
     self.enableFlash = enabled
     updateFlash()

--- a/ios/RNVisionCameraView.swift
+++ b/ios/RNVisionCameraView.swift
@@ -701,6 +701,7 @@ class RNVisionCameraView: UIView {
     detectionSettings.isTextIndicationOn = config["text"] as? Bool ?? false
     detectionSettings.isBarCodeOrQRCodeIndicationOn = config["barcode"] as? Bool ?? false
     detectionSettings.isDocumentIndicationOn = config["document"] as? Bool ?? false
+    detectionSettings.isImageSharpnessIndicationOn = config["sharpness"] as? Bool ?? false
     detectionSettings.codeDetectionConfidence = config["barcodeConfidence"] as? Float ?? 0.5
     detectionSettings.documentDetectionConfidence = config["documentConfidence"] as? Float ?? 0.5
     detectionSettings.secondsToWaitBeforeDocumentCapture = config["documentCaptureDelay"] as? Double ?? 2.0
@@ -717,6 +718,7 @@ class RNVisionCameraView: UIView {
       detectionSettings.isTextIndicationOn = config["text"] as? Bool ?? false
       detectionSettings.isBarCodeOrQRCodeIndicationOn = config["barcode"] as? Bool ?? false
       detectionSettings.isDocumentIndicationOn = config["document"] as? Bool ?? false
+      detectionSettings.isImageSharpnessIndicationOn = config["sharpness"] as? Bool ?? false
       detectionSettings.codeDetectionConfidence = config["barcodeConfidence"] as? Float ?? 0.5
       detectionSettings.documentDetectionConfidence = config["documentConfidence"] as? Float ?? 0.5
       detectionSettings.secondsToWaitBeforeDocumentCapture = config["documentCaptureDelay"] as? Double ?? 2.0

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "ios",
     "cpp",
     "*.podspec",
+    "react-native.config.cjs",
     "!lib/typescript/example",
     "!ios/build",
     "!android/build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-sdk",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "VisionSDK for React Native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -45,9 +45,9 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
   # Core scanner + OCR
-  s.dependency "VisionSDK", "= 2.3.5"
+  s.dependency "VisionSDK", "= 2.3.13"
   # 3-D box measurement — brings MVDimensioningCore.xcframework, ARKit, RealityKit, PostHog
-  s.dependency "VisionSDK/Dimensioning", "= 2.3.5"
+  s.dependency "VisionSDK/Dimensioning", "= 2.3.13"
 
   # New Architecture dependencies
   install_modules_dependencies(s)

--- a/react-native.config.cjs
+++ b/react-native.config.cjs
@@ -1,0 +1,23 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        // @react-native-community/cli-config-android's dependencyConfig() falls back to
+        // findComponentDescriptors(root), which fast-glob-walks the ENTIRE package root
+        // (only node_modules is excluded) looking for codegenNativeComponent() calls.
+        // In this repo that root also contains .worktrees/ (gitignored git worktrees used
+        // for parallel feature branches), one of which has its own example/node_modules
+        // symlink pointing back to its own root — an infinite symlink loop that crashes
+        // with ENAMETOOLONG during `pod install` (use_native_modules!) and Xcode's
+        // "Bundle React Native code and images" phase, both of which call `react-native config`.
+        //
+        // Declaring the descriptors explicitly (matching src/specs/*NativeComponent.ts +
+        // codegenConfig in package.json) skips that recursive scan entirely.
+        componentDescriptors: [
+          'VisionCameraViewComponentDescriptor',
+          'DimensioningViewComponentDescriptor',
+        ],
+      },
+    },
+  },
+};

--- a/src/VisionCamera.tsx
+++ b/src/VisionCamera.tsx
@@ -123,6 +123,18 @@ const Camera = forwardRef<VisionCameraRefProps, VisionCameraProps>(
           Commands.setFocusSettings(VisionCameraViewRef.current, JSON.stringify(settings));
         }
       },
+
+      pauseDetection: () => {
+        if (VisionCameraViewRef.current) {
+          Commands.pauseDetection(VisionCameraViewRef.current);
+        }
+      },
+
+      resumeDetection: () => {
+        if (VisionCameraViewRef.current) {
+          Commands.resumeDetection(VisionCameraViewRef.current);
+        }
+      },
     }), []);
 
     // All handlers use refs — permanently stable, never cause native view prop updates

--- a/src/VisionCameraTypes.ts
+++ b/src/VisionCameraTypes.ts
@@ -238,7 +238,7 @@ export interface DetectionConfig {
    * @optional
    * @type {boolean}
    * @description Enable/disable text detection.
-   * @default true
+   * @default false
    */
   text?: boolean;
 
@@ -246,7 +246,7 @@ export interface DetectionConfig {
    * @optional
    * @type {boolean}
    * @description Enable/disable barcode/QR code detection.
-   * @default true
+   * @default false
    */
   barcode?: boolean;
 
@@ -254,7 +254,7 @@ export interface DetectionConfig {
    * @optional
    * @type {boolean}
    * @description Enable/disable document detection.
-   * @default true
+   * @default false
    */
   document?: boolean;
 

--- a/src/VisionCameraTypes.ts
+++ b/src/VisionCameraTypes.ts
@@ -260,6 +260,18 @@ export interface DetectionConfig {
 
   /**
    * @optional
+   * @type {boolean}
+   * @description Enable/disable image sharpness scoring. iOS gates the
+   * Laplacian sharpness computation in the native SDK behind this flag
+   * (opt-in — avoids new Neural Engine/CPU work for existing consumers who
+   * never asked for sharpness feedback). Android already computes sharpness
+   * only when this flag is set.
+   * @default false
+   */
+  sharpness?: boolean;
+
+  /**
+   * @optional
    * @type {number}
    * @description Minimum confidence threshold for barcode detection (0.0-1.0).
    * @default 0.5

--- a/src/VisionCameraTypes.ts
+++ b/src/VisionCameraTypes.ts
@@ -701,6 +701,23 @@ export interface VisionCameraRefProps {
    * @param {FocusSettings} settings - The focus settings to apply.
    */
   setFocusSettings: (settings: FocusSettings) => void;
+
+  /**
+   * Pauses detection while keeping the camera session/preview alive.
+   * @description Mode-agnostic universal pause: stops the underlying
+   * per-frame Vision/CoreML (iOS) or MLKit/ONNX (Android) analysis work
+   * without stopping the camera session/preview, and clears any in-flight
+   * detection overlays. Use this instead of stop()/start() for a "captured,
+   * showing loading spinner" moment where the live preview should stay
+   * visible. Does not affect capture()/captureImage() or the Dimensioning
+   * module (out of scope by design).
+   */
+  pauseDetection: () => void;
+
+  /**
+   * Resumes detection after a pauseDetection() call.
+   */
+  resumeDetection: () => void;
 }
 
 /**

--- a/src/VisionCameraViewManager.ts
+++ b/src/VisionCameraViewManager.ts
@@ -29,7 +29,7 @@ const VisionCameraViewWrapper = React.forwardRef<any, VisionCameraViewProps>((pr
   const detectionConfigJson = React.useMemo(
     () => (detectionConfig && typeof detectionConfig === 'object') ? JSON.stringify(detectionConfig) : '',
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [detectionConfig?.text, detectionConfig?.barcode, detectionConfig?.document, detectionConfig?.documentConfidence, detectionConfig?.documentCaptureDelay, detectionConfig?.barcodeConfidence]
+    [detectionConfig?.text, detectionConfig?.barcode, detectionConfig?.document, detectionConfig?.documentConfidence, detectionConfig?.documentCaptureDelay, detectionConfig?.barcodeConfidence, detectionConfig?.sharpness]
   );
 
   const templateJson = React.useMemo(

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -20,6 +20,8 @@ jest.mock('../specs/VisionCameraViewNativeComponent', () => {
       toggleFlash: jest.fn(),
       setZoom: jest.fn(),
       setFocusSettings: jest.fn(),
+      pauseDetection: jest.fn(),
+      resumeDetection: jest.fn(),
     },
   };
 });
@@ -189,6 +191,30 @@ describe('VisionCamera', () => {
 
       expect(Commands.rescan).toHaveBeenCalledTimes(1);
       expect(Commands.rescan).toHaveBeenCalledWith(expect.anything());
+    });
+
+    it('pauseDetection dispatches Commands.pauseDetection with the view ref', () => {
+      const ref = React.createRef<any>();
+      renderInAct(<VisionCamera ref={ref} />);
+
+      act(() => {
+        ref.current.pauseDetection();
+      });
+
+      expect(Commands.pauseDetection).toHaveBeenCalledTimes(1);
+      expect(Commands.pauseDetection).toHaveBeenCalledWith(expect.anything());
+    });
+
+    it('resumeDetection dispatches Commands.resumeDetection with the view ref', () => {
+      const ref = React.createRef<any>();
+      renderInAct(<VisionCamera ref={ref} />);
+
+      act(() => {
+        ref.current.resumeDetection();
+      });
+
+      expect(Commands.resumeDetection).toHaveBeenCalledTimes(1);
+      expect(Commands.resumeDetection).toHaveBeenCalledWith(expect.anything());
     });
   });
 });

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -225,5 +225,30 @@ describe('VisionCameraViewManager', () => {
       expect(nativeView.props.detectionConfig).toBeUndefined();
     });
 
+    it('includes sharpness in detectionConfigJson and recomputes when only sharpness changes', () => {
+      const baseConfig = { text: true, barcode: true, document: false };
+      const tree = renderInAct(
+        <VisionCameraView detectionConfig={{ ...baseConfig, sharpness: false }} />
+      );
+      const getNativeView = () => {
+        const views = tree.root.findAllByType('View' as any);
+        return views[views.length - 1]!;
+      };
+
+      expect(getNativeView().props.detectionConfigJson).toBe(
+        JSON.stringify({ ...baseConfig, sharpness: false })
+      );
+
+      act(() => {
+        tree.update(
+          <VisionCameraView detectionConfig={{ ...baseConfig, sharpness: true }} />
+        );
+      });
+
+      expect(getNativeView().props.detectionConfigJson).toBe(
+        JSON.stringify({ ...baseConfig, sharpness: true })
+      );
+    });
+
   });
 });

--- a/src/specs/VisionCameraViewNativeComponent.ts
+++ b/src/specs/VisionCameraViewNativeComponent.ts
@@ -93,10 +93,12 @@ interface NativeCommands {
   toggleFlash: (viewRef: React.ElementRef<HostComponent<NativeProps>>, enabled: boolean) => void;
   setZoom: (viewRef: React.ElementRef<HostComponent<NativeProps>>, level: Float) => void;
   setFocusSettings: (viewRef: React.ElementRef<HostComponent<NativeProps>>, settingsJson: string) => void;
+  pauseDetection: (viewRef: React.ElementRef<HostComponent<NativeProps>>) => void;
+  resumeDetection: (viewRef: React.ElementRef<HostComponent<NativeProps>>) => void;
 }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ['capture', 'stop', 'start', 'rescan', 'toggleFlash', 'setZoom', 'setFocusSettings'],
+  supportedCommands: ['capture', 'stop', 'start', 'rescan', 'toggleFlash', 'setZoom', 'setFocusSettings', 'pauseDetection', 'resumeDetection'],
 });
 
 export default codegenNativeComponent<NativeProps>(


### PR DESCRIPTION
## Summary

Brings the react-native-vision-sdk wrapper up to date with the detection-pause-gating work already released on both native SDKs (vision-sdk-ios v2.3.13, vision-sdk-android v2.4.55):

- Adds `pauseDetection()`/`resumeDetection()` imperative ref API, bridged to both native platforms.
- Adds `sharpness` flag to `DetectionConfig` (opt-in, default `false`), forwarded to both native SDKs.
- Fixes an iOS default-flags inconsistency (`detectionConfig` flags now default to `false`, matching Android).
- Bumps native SDK pins: `vision-sdk-android` → `v2.4.55` (JitPack), `VisionSDK`/`VisionSDK/Dimensioning` (iOS) → `2.3.13`.
- Fixes an invalid `import VisionSDKDimensioning` in the iOS native module bridge — CocoaPods compiles the `VisionSDK/Core` + `VisionSDK/Dimensioning` subspecs into a single `VisionSDK` module, so that import could never resolve.
- Fixes a permanent RN CLI autolinking crash (`ENAMETOOLONG`) caused by a symlink cycle when a git worktree sits alongside this repo's own tree — explicit `componentDescriptors` now skip the recursive scan.
- Example app (`ScannerScreen.tsx`):
  - Adds a "Detection Enabled" toggle wired to `pauseDetection()`/`resumeDetection()`, auto-resyncing on scan-mode switch (matches native demo-app behavior on both platforms).
  - Enables `sharpness: true` in `detectionConfig` — previously omitted, so the sharpness readout was permanently frozen at its initial value.
  - Clears the JS-rendered bounding-box overlay on pause and mode-switch — previously stale boxes stayed drawn on screen after either action (same stale-overlay bug class already fixed natively in vision-sdk-ios/vision-sdk-android, reintroduced here in this separate JS-side overlay).

