### PR TITLE
fix(ci): pin npm to 11.x for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      # Pinned to the 11.x line, not @latest: npm 12.0.0 (released 2026-07-08)
+      # shipped with a packaging bug where the `sigstore` module is missing
+      # from the published npm-12.0.0.tgz even though libnpmpublish still
+      # requires it for provenance/trusted publishing, crashing every publish
+      # with `Cannot find module 'sigstore'`. 11.x still bundles it correctly.
+      # Upstream bug: https://github.com/npm/cli/issues/9722 (open, unfixed).
       - name: Upgrade npm for trusted publishing
-        run: sudo npm install -g npm@latest
+        run: sudo npm install -g npm@11
 
       - name: Build package
         run: yarn prepare


### PR DESCRIPTION
## Summary

The Release workflow has been failing every publish since npm `12.0.0` was released (2026-07-08), including the merge of #190 - it never actually published to npm despite the merge succeeding.

**Root cause**: `npm 12.0.0` shipped with a packaging bug - the `sigstore` module is missing from the published `npm-12.0.0.tgz`, even though `libnpmpublish`'s `provenance.js` still requires it for our OIDC-based trusted publishing (`permissions: id-token: write`). Every `npm publish` crashes with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
```

Confirmed as an upstream npm bug, not anything on our end - see [npm/cli#9722](https://github.com/npm/cli/issues/9722) (open, unfixed at time of writing). A commenter there verified via `tar tzf` that `npm-11.18.0.tgz` bundles `sigstore` correctly while `npm-12.0.0.tgz` does not.

**Fix**: pin the "Upgrade npm for trusted publishing" step to `npm@11` instead of `npm@latest`, until npm ships a patched 12.x.

## Test plan

- [ ] Merge and confirm the next Release workflow run actually completes `npm publish` successfully (currently blocked on every run since 2026-07-08)