### PR TITLE
chore(ios): bump VisionSDK to 2.3.14

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -57,8 +57,8 @@ target 'VisionSdkExample' do
 
   # VisionSDK from CocoaPods trunk. Matches the deps declared by the
   # react-native-vision-sdk podspec; pinned explicitly here for clarity.
-  pod 'VisionSDK', '= 2.3.5'
-  pod 'VisionSDK/Dimensioning', '= 2.3.5'
+  pod 'VisionSDK', '= 2.3.14'
+  pod 'VisionSDK/Dimensioning', '= 2.3.14'
 
   use_react_native!(
     :path => config[:reactNativePath],

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - PostHog (3.61.0)
+  - PostHog (3.66.1)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -1870,7 +1870,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-vision-sdk (3.5.0):
+  - react-native-vision-sdk (3.8.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1897,8 +1897,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-    - VisionSDK (= 2.3.5)
-    - VisionSDK/Dimensioning (= 2.3.5)
+    - VisionSDK (= 2.3.14)
+    - VisionSDK/Dimensioning (= 2.3.14)
     - Yoga
   - React-NativeModulesApple (0.82.1):
     - boost
@@ -2849,10 +2849,10 @@ PODS:
     - SocketRocket
     - Yoga
   - SocketRocket (0.7.1)
-  - VisionSDK (2.3.5):
-    - VisionSDK/Core (= 2.3.5)
-  - VisionSDK/Core (2.3.5)
-  - VisionSDK/Dimensioning (2.3.5):
+  - VisionSDK (2.3.14):
+    - VisionSDK/Core (= 2.3.14)
+  - VisionSDK/Core (2.3.14)
+  - VisionSDK/Dimensioning (2.3.14):
     - PostHog (~> 3.0)
     - VisionSDK/Core
   - Yoga (0.0.0)
@@ -2942,8 +2942,8 @@ DEPENDENCIES:
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - RNWorklets (from `../node_modules/react-native-worklets`)
   - SocketRocket (~> 0.7.1)
-  - VisionSDK (= 2.3.5)
-  - VisionSDK/Dimensioning (= 2.3.5)
+  - VisionSDK (= 2.3.14)
+  - VisionSDK/Dimensioning (= 2.3.14)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -3129,8 +3129,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  PostHog: 82eee1ba92efc8144b06b6e4412abba5438c8fda
-  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
+  PostHog: f906c839bed59a21eb853587afc7fc303b492382
+  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: f17e2ebc07876ca9ab8eb6e4b0a4e4647497ae3a
   RCTRequired: e2c574c1b45231f7efb0834936bd609d75072b63
   RCTTypeSafety: c693294e3993056955c3010eb1ebc574f1fcded6
@@ -3164,7 +3164,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 06d59c448da7e34eb05b3fb2189e12f6a30fec57
   React-microtasksnativemodule: d1ee999dc9052e23f6488b730fa2d383a4ea40e5
   react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
-  react-native-vision-sdk: a1b12313dc1ef9e19e451d3e2ee81435407034ee
+  react-native-vision-sdk: 4191e438a696f6769d31469aed481586dd6b8ce9
   React-NativeModulesApple: 46690a0fe94ec28fc6fc686ec797b911d251ded0
   React-oscompat: 95875e81f5d4b3c7b2c888d5bd2c9d83450d8bdb
   React-perflogger: 2e229bf33e42c094fd64516d89ec1187a2b79b5b
@@ -3206,9 +3206,9 @@ SPEC CHECKSUMS:
   RNVectorIcons: 791f13226ec4a3fd13062eda9e892159f0981fae
   RNWorklets: ab618bf7d1c7fd2cb793b9f0f39c3e29274b3ebf
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  VisionSDK: f0c559b7a0bdecc6f3b0eb7b734b5cc1551d0427
+  VisionSDK: cf422ee36903b889ef72d261d40aaf02abe475de
   Yoga: 689c8e04277f3ad631e60fe2a08e41d411daf8eb
 
-PODFILE CHECKSUM: 6af194c34d09241093c1333353bbbce24e0512c4
+PODFILE CHECKSUM: e074ac5ec1c256663ea5a2e96c7de4be8d3100c0
 
 COCOAPODS: 1.16.2

--- a/ios/DimensioningModule.swift
+++ b/ios/DimensioningModule.swift
@@ -1,5 +1,6 @@
 import Foundation
 import VisionSDK
+import VisionSDKDimensioning
 
 // MARK: - DimensioningModule
 //

--- a/ios/RNDimensioningView.swift
+++ b/ios/RNDimensioningView.swift
@@ -1,5 +1,6 @@
 import UIKit
 import VisionSDK
+import VisionSDKDimensioning
 
 // MARK: - RNDimensioningView
 //

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-sdk",
-  "version": "3.9.0",
+  "version": "3.8.0",
   "description": "VisionSDK for React Native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-sdk",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "VisionSDK for React Native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -45,9 +45,9 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
   # Core scanner + OCR
-  s.dependency "VisionSDK", "= 2.3.13"
+  s.dependency "VisionSDK", "= 2.3.14"
   # 3-D box measurement — brings MVDimensioningCore.xcframework, ARKit, RealityKit, PostHog
-  s.dependency "VisionSDK/Dimensioning", "= 2.3.13"
+  s.dependency "VisionSDK/Dimensioning", "= 2.3.14"
 
   # New Architecture dependencies
   install_modules_dependencies(s)


### PR DESCRIPTION
## Summary
- Bumps the pinned iOS `VisionSDK` CocoaPod dependency from `2.3.13` to `2.3.14` in `react-native-vision-sdk.podspec` (both the `VisionSDK` and `VisionSDK/Dimensioning` subspec pins).
