### PR TITLE
fix(android): bump vision-sdk-android to v2.4.56

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -155,7 +155,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 // From node_modules
-  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.55'
+  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.56'
   implementation 'com.github.asadullahilyas:HandyUtils:1.1.6'
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-sdk",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "VisionSDK for React Native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-sdk",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "description": "VisionSDK for React Native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary

- Bumps the JitPack coordinate in `android/build.gradle` from `v2.4.55` to `v2.4.56`.
- v2.4.56 is a hotfix on vision-sdk-android's `main`: replaces the synchronous 5-second-timeout TFLite init (which crashed the process on devices where GMS TFLite init is slow/failing, e.g. Zebra TC73) with a deferred async init.
  - ZBar/ZXing decode CV-only from frame one.
  - ML detection activates once `TfLite.initialize()` succeeds in the background, via a GPU-delegate -> CPU-only-init -> XNNPACK fallback ladder with a 3x retry loop.
- Pure Kotlin change, no C++/iOS/camera-core changes. No public API changes to `VisionScanner` (the touched class, `BarcodeScanAnalyzer`, is internal). `zbarscanner`'s `ZBarScanner` gained new public `deferInit` config + `activateMLDetection()` members (additive only, no wiring needed on the RN side).

