### PR TITLE
feat(camera-controls): Phase 3 API + bump vision-sdk-android v2.5.0 / VisionSDK 2.4.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -155,7 +155,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 // From node_modules
-  implementation 'com.github.packagexlabs:vision-sdk-android:v2.4.56'
+  implementation 'com.github.packagexlabs:vision-sdk-android:v2.5.0'
   implementation 'com.github.asadullahilyas:HandyUtils:1.1.6'
 }
 

--- a/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
+++ b/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
@@ -75,9 +75,275 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
     private var currentDetectionMode: DetectionMode = DetectionMode.Photo // Track current detection mode
     private val density = appContext.resources.displayMetrics.density
 
+    // Camera Controls API (Phase 3) — per-view CameraSettings, tracked the same way as
+    // overlayStates above (a single ViewManager instance is shared across all camera views).
+    private val cameraSettingsByView = java.util.WeakHashMap<VisionCameraView, io.packagex.visionsdk.config.CameraSettings>()
+    private fun cameraSettingsFor(view: VisionCameraView): io.packagex.visionsdk.config.CameraSettings =
+        cameraSettingsByView.getOrPut(view) { io.packagex.visionsdk.config.CameraSettings() }
+
+    // Camera Controls API (Phase 3) — last JS-declared value for the "persistent" control
+    // props (torch/zoomRatio/focusMode/pinnedLensId). The underlying native camera core
+    // resets these on a genuine facing/lens change (input-device swap), so we re-apply them
+    // ourselves on every transition into CameraStatus.RUNNING (§8). Legacy aliases
+    // (enableFlash/zoomLevel) and the setTorchEnabled/setZoom commands feed the same
+    // tracked state via applyTorch/applyZoomRatio so reassertion works regardless of
+    // which prop/command name a consumer used. setFocusPoint is a one-shot action and is
+    // deliberately NOT tracked/reasserted here.
+    private data class ControlPropsState(
+        var torch: Boolean = false,
+        var zoomRatio: Double = 1.0,
+        var focusMode: String = "continuous",
+        var pinnedLensId: String? = null,
+        // Review fix (Group D #4) — tracks the lens selection actually applied via
+        // applyLensSelection, so reassertControlProps can skip re-applying an unchanged
+        // selection. setLensSelection -> cameraSession.update -> performReconcile does an
+        // UNCONDITIONAL unbind/rebind, so reasserting on every RUNNING transition (incl.
+        // ordinary start with no pin) was flapping isPreviewActive / double-binding at
+        // startup. The lens already persists across rebinds via cameraConfigurationFromSettings
+        // (Group A), so we only need to re-apply when the resolved selection actually changes.
+        var lastAppliedLensId: String? = null,
+        var lensApplied: Boolean = false,
+        // Review fix (parity #1) — last CameraLensFace delivered via the `cameraFacing`
+        // prop (setCameraFacing), tracked independently of
+        // cameraSettingsByView[view].cameraLensFace because applyLensSelection's
+        // cross-facing pin path overwrites that settings object's facing to match the
+        // PINNED lens. Without a separate record of the prop's own value, unpinning
+        // (Auto) had nothing to restore to and Android was left stuck on whichever
+        // facing the last pin happened to use — iOS's cameraFacing is a plain stored
+        // prop and correctly falls back to it on unpin (see RNVisionCameraView.swift
+        // syncFacing/currentFacing). See applyLensSelection's Auto/unknown-lens branches.
+        var propCameraFacing: io.packagex.visionsdk.core.CameraLensFace = io.packagex.visionsdk.core.CameraLensFace.Back,
+    )
+    private val controlPropsByView = java.util.WeakHashMap<VisionCameraView, ControlPropsState>()
+    private fun controlPropsFor(view: VisionCameraView): ControlPropsState =
+        controlPropsByView.getOrPut(view) { ControlPropsState() }
+
+    private fun applyTorch(view: VisionCameraView, enabled: Boolean) {
+        controlPropsFor(view).torch = enabled
+        view.setFlashTurnedOn(enabled)
+    }
+
+    private fun applyZoomRatio(view: VisionCameraView, ratio: Float) {
+        controlPropsFor(view).zoomRatio = ratio.toDouble()
+        view.setZoomRatio(ratio)
+    }
+
+    private fun focusModeFromString(mode: String?): io.packagex.visionsdk.camera.core.FocusMode =
+        when (mode?.lowercase()) {
+            "single" -> io.packagex.visionsdk.camera.core.FocusMode.SINGLE
+            "locked" -> io.packagex.visionsdk.camera.core.FocusMode.LOCKED
+            else -> io.packagex.visionsdk.camera.core.FocusMode.CONTINUOUS
+        }
+
+    private fun applyFocusMode(view: VisionCameraView, mode: String?) {
+        controlPropsFor(view).focusMode = mode ?: "continuous"
+        view.setFocusMode(focusModeFromString(mode))
+    }
+
+    // Review fix (parity #1, Android/iOS unpin restore) — bring the view's camera
+    // facing back in line with the last `cameraFacing` prop value. Mirrors iOS's
+    // `syncFacing(to: currentFacing, ...)` calls in its Auto/unknown-lens branches:
+    // a cross-facing pin overwrites cameraSettingsByView's facing to match the
+    // PINNED lens (see the bottom of this function), and nothing else ever resets
+    // it back, so unpinning left Android on the wrong camera while iOS correctly
+    // returned to the `cameraFacing` prop. No-op when facing already matches (same
+    // guard style as the cross-facing pin path below).
+    private fun restoreFacingFromProp(view: VisionCameraView) {
+        val propFacing = controlPropsFor(view).propCameraFacing
+        if (cameraSettingsFor(view).cameraLensFace != propFacing) {
+            val updated = cameraSettingsFor(view).copy(cameraLensFace = propFacing)
+            cameraSettingsByView[view] = updated
+            view.setCameraSettings(updated)
+        }
+    }
+
+    private fun applyLensSelection(view: VisionCameraView, lensId: String?) {
+        // Review fix (Group D #5) — a cleared Fabric optional-string prop can arrive as
+        // "" rather than null; treat it the same as unpin/Auto (matches iOS).
+        if (lensId.isNullOrEmpty()) {
+            controlPropsFor(view).apply {
+                lastAppliedLensId = null
+                lensApplied = true
+            }
+            restoreFacingFromProp(view)
+            view.setLensSelection(io.packagex.visionsdk.camera.core.LensSelection.Auto)
+            return
+        }
+        controlPropsFor(view).apply {
+            lastAppliedLensId = lensId
+            lensApplied = true
+        }
+        // Bug fix (QA Group A #2) — a pinnable lens id only ever appears under its OWN
+        // facing's list (a front lens is never returned by lenses(BACK) and vice versa), so
+        // gating this lookup to whatever facing happens to be currently applied meant
+        // pinning a lens from the OTHER facing silently fell back to Auto with a warning —
+        // reproduced on-device: pin id=5 (front) while cameraFacing is still "back" logs
+        // "pinnedLensId '5' unknown or unpinnable for facing=BACK". Search both facings so
+        // the pin resolves regardless of prop-set order, then bring the camera's facing in
+        // line with whichever facing the resolved lens actually belongs to.
+        val snapshot = io.packagex.visionsdk.camera.core.CameraCapabilities.snapshot(appContext)
+        val lens = (
+            snapshot.lenses(io.packagex.visionsdk.camera.core.LensFacing.BACK) +
+                snapshot.lenses(io.packagex.visionsdk.camera.core.LensFacing.FRONT)
+            ).firstOrNull { it.id == lensId && it.isPinnable }
+        if (lens == null) {
+            Log.w(TAG, "pinnedLensId '$lensId' unknown or unpinnable — falling back to Auto")
+            restoreFacingFromProp(view)
+            view.setLensSelection(io.packagex.visionsdk.camera.core.LensSelection.Auto)
+            markPendingLensUnavailableWarning(view)
+            return
+        }
+        // setLensSelection() builds its CameraConfiguration from cameraSettingsFacing()
+        // (see VisionCameraView.setLensSelection), so facing and the pinned lens must agree
+        // before we hand it off — otherwise the SDK is asked to pin a lens under a facing
+        // it doesn't belong to.
+        val neededFacing = if (lens.facing == io.packagex.visionsdk.camera.core.LensFacing.FRONT)
+            io.packagex.visionsdk.core.CameraLensFace.Front
+        else io.packagex.visionsdk.core.CameraLensFace.Back
+        if (cameraSettingsFor(view).cameraLensFace != neededFacing) {
+            val updated = cameraSettingsFor(view).copy(cameraLensFace = neededFacing)
+            cameraSettingsByView[view] = updated
+            view.setCameraSettings(updated)
+        }
+        view.setLensSelection(io.packagex.visionsdk.camera.core.LensSelection.Pin(lens))
+    }
+
+    // Re-apply the last JS-declared control props onto a fresh camera session. Called on
+    // every transition into CameraStatus.RUNNING (initial start, and post facing/lens-switch
+    // stop+start cycles) since the native core resets torch/zoom/focusMode on those (§5.4).
+    // Torch/zoom/focusMode are cheap runtime settings and always reassert. The lens selection
+    // is different — setLensSelection triggers a full unbind/rebind (Group D #4) — so it's
+    // only re-applied when the resolved selection actually differs from what's currently
+    // applied; otherwise an ordinary start-with-no-pin would unbind/rebind for nothing.
+    private fun reassertControlProps(view: VisionCameraView) {
+        val props = controlPropsByView[view] ?: return
+        view.setFlashTurnedOn(props.torch)
+        view.setZoomRatio(props.zoomRatio.toFloat())
+        view.setFocusMode(focusModeFromString(props.focusMode))
+        if (!props.lensApplied || props.lastAppliedLensId != props.pinnedLensId) {
+            applyLensSelection(view, props.pinnedLensId)
+        }
+    }
+
+    // Camera Controls API (Phase 3) — one-shot warning stashed when a requested
+    // pinnedLensId can't be resolved; merged into the very next emitted CameraStateEvent
+    // (bypassing the throttle) rather than fired as its own event.
+    private data class PendingLensWarning(var flagged: Boolean = false)
+    private val pendingLensWarnings = java.util.WeakHashMap<VisionCameraView, PendingLensWarning>()
+    private fun markPendingLensUnavailableWarning(view: VisionCameraView) {
+        pendingLensWarnings.getOrPut(view) { PendingLensWarning() }.flagged = true
+    }
+
+    // Camera Controls API (Phase 3) — throttled onCameraStateChanged emission bookkeeping.
+    private val CAMERA_STATE_THROTTLE_MS = 100L // 10 Hz, matches RECOGNITION_UPDATE_THROTTLE_MS convention
+    private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
+    private data class CameraStateEmitState(
+        var lastEmitTime: Long = 0L,
+        var lastStatus: String? = null,
+        // Review fix (Group D #1, trailing-edge throttle) — the runnable scheduled to
+        // deliver the latest dropped state at the window boundary, so a burst ending
+        // mid-window doesn't leave JS stuck on a stale value. Replaced (not queued) on
+        // every subsequent drop so only the LATEST state is ever pending.
+        var pendingTrailingRunnable: Runnable? = null,
+    )
+    private val cameraStateEmitStates = java.util.WeakHashMap<VisionCameraView, CameraStateEmitState>()
+    private val cameraStateListenersByView = java.util.WeakHashMap<VisionCameraView, io.packagex.visionsdk.camera.core.CameraStateListener>()
+
+    private fun mapCameraErrorCode(error: io.packagex.visionsdk.camera.core.CameraError): String =
+        when (error) {
+            is io.packagex.visionsdk.camera.core.CameraError.PermissionDenied -> "permission-denied"
+            is io.packagex.visionsdk.camera.core.CameraError.LensUnavailable -> "lens-unavailable"
+            is io.packagex.visionsdk.camera.core.CameraError.ConfigurationFailed -> "configuration-failed"
+        }
+
+    private fun cameraStateToMap(
+        view: VisionCameraView,
+        state: io.packagex.visionsdk.camera.core.CameraState
+    ): com.facebook.react.bridge.WritableMap {
+        val map = Arguments.createMap()
+        map.putString("status", state.status.name.lowercase())
+        state.error?.let {
+            map.putString("errorCode", mapCameraErrorCode(it))
+            map.putString("errorMessage", it.toString())
+        }
+        val pendingWarning = pendingLensWarnings[view]
+        val warning = state.warning
+        if (warning != null) {
+            map.putString("warningCode", mapCameraErrorCode(warning))
+            map.putString("warningMessage", warning.toString())
+        } else if (pendingWarning?.flagged == true) {
+            map.putString("warningCode", "lens-unavailable")
+            map.putString("warningMessage", "pinnedLensId unavailable — falling back to Auto")
+            pendingWarning.flagged = false // one-shot; consumed
+        }
+        map.putString("facing", if (state.facing == io.packagex.visionsdk.camera.core.LensFacing.FRONT) "front" else "back")
+        state.activeLens?.let { map.putString("activeLensId", it.id) }
+        map.putDouble("zoomRatio", state.zoomRatio.toDouble())
+        map.putDouble("minZoomRatio", state.minZoomRatio.toDouble())
+        map.putDouble("maxZoomRatio", state.maxZoomRatio.toDouble())
+        map.putBoolean("torchEnabled", state.isTorchEnabled)
+        map.putString("focusMode", state.focusMode.name.lowercase())
+        map.putBoolean("isPreviewActive", state.isPreviewActive)
+        return map
+    }
+
+    private fun emitCameraState(view: VisionCameraView, state: io.packagex.visionsdk.camera.core.CameraState, bypassThrottle: Boolean) {
+        val emitState = cameraStateEmitStates.getOrPut(view) { CameraStateEmitState() }
+        val newStatus = state.status.name
+        val statusChanged = emitState.lastStatus != newStatus
+        if (statusChanged && newStatus.equals("RUNNING", ignoreCase = true)) {
+            reassertControlProps(view)
+        }
+        // Review fix (Group D #2) — a pending lens-unavailable warning must bypass the
+        // throttle immediately (it's a one-shot notice, not a value that survives being
+        // superseded), not just ride along on whatever unrelated emission happens next.
+        val hasPendingLensWarning = pendingLensWarnings[view]?.flagged == true
+        val now = System.currentTimeMillis()
+        val bypass = bypassThrottle || statusChanged || state.error != null || state.warning != null || hasPendingLensWarning
+        val shouldEmit = bypass || shouldEmitThrottledEvent(emitState.lastEmitTime, CAMERA_STATE_THROTTLE_MS)
+
+        // Any newer state (emitted or dropped) supersedes a previously scheduled trailing
+        // emit — cancel it so we never deliver a stale value after a fresher one.
+        emitState.pendingTrailingRunnable?.let { mainHandler.removeCallbacks(it) }
+        emitState.pendingTrailingRunnable = null
+
+        if (!shouldEmit) {
+            // Review fix (Group D #1) — trailing-edge throttle. This is a drop-throttle:
+            // without this, a burst ending inside the throttle window leaves JS with a
+            // stale value forever. Schedule the LATEST dropped state to fire at the
+            // window boundary; a later emit (immediate or another scheduled trailing
+            // one) will cancel/replace this via the removeCallbacks above.
+            val delay = (CAMERA_STATE_THROTTLE_MS - (now - emitState.lastEmitTime)).coerceIn(0L, CAMERA_STATE_THROTTLE_MS)
+            val runnable = Runnable { doEmitCameraState(view, state, emitState) }
+            emitState.pendingTrailingRunnable = runnable
+            mainHandler.postDelayed(runnable, delay)
+            return
+        }
+        doEmitCameraState(view, state, emitState)
+    }
+
+    private fun doEmitCameraState(view: VisionCameraView, state: io.packagex.visionsdk.camera.core.CameraState, emitState: CameraStateEmitState) {
+        emitState.lastEmitTime = System.currentTimeMillis()
+        emitState.lastStatus = state.status.name
+        emitState.pendingTrailingRunnable = null
+        // Review fix (C1) — view.context is the FragmentActivity passed into
+        // VisionCameraView(activity, null) at construction (createViewInstance), never a
+        // ThemedReactContext, so `view.context as? ThemedReactContext` always failed and
+        // silently dropped every onCameraStateChanged emission. Resolve the JS module from
+        // the captured ReactApplicationContext instead — the same path ViewCallback.sendEvent
+        // already uses successfully for the other camera events.
+        try {
+            appContext.getJSModule(RCTEventEmitter::class.java)
+                .receiveEvent(view.id, "onCameraStateChanged", cameraStateToMap(view, state))
+        } catch (e: Exception) {
+            // The state callback can arrive after the view/context has been torn down
+            // (e.g. mid onDropViewInstance) — never crash the camera pipeline over a
+            // best-effort JS event.
+            Log.w(TAG, "Failed to emit onCameraStateChanged (view/context likely torn down): ${e.message}")
+        }
+    }
+
     // Event throttling - timestamps for last emitted events
-    private var lastRecognitionUpdateTime = 0L
-    private val RECOGNITION_UPDATE_THROTTLE_MS = 100L // 10 FPS
     private var lastSharpnessScoreUpdateTime = 0L
 
     // Throttle intervals in milliseconds
@@ -115,6 +381,18 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
         newView.setCameraLifecycleCallback(callback)
         newView.setScannerCallback(callback)
 
+        // Camera Controls API (Phase 3) — subscribe to full CameraState changes so
+        // `useCameraControls().state` tracks the camera going forward. The one-shot
+        // replay-on-attach emit (§8) is deliberately NOT done here — see
+        // onAfterUpdateTransaction (Group D review fix #3): at this point Fabric hasn't
+        // assigned the view's react tag yet, so receiveEvent(NO_ID, ...) is silently
+        // discarded and JS never mounted its handlers anyway.
+        val cameraStateListener = io.packagex.visionsdk.camera.core.CameraStateListener { state ->
+            emitCameraState(newView, state, bypassThrottle = false)
+        }
+        newView.addCameraStateListener(cameraStateListener)
+        cameraStateListenersByView[newView] = cameraStateListener
+
         // Update the current view reference and callback
         visionCameraView = newView
         currentCallback = callback
@@ -124,14 +402,46 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
         return newView
     }
 
+    // Review fix (Group D #3) — one-shot guard for the replay-on-attach emit below.
+    // WeakHashMap so a dropped/GC'd view doesn't pin this entry.
+    private val hasReplayedInitialCameraState = java.util.WeakHashMap<VisionCameraView, Boolean>()
+
+    // Bug fix (post QA Group A #1 regression) — the mount-time "start camera once" gate
+    // below used to share `hasStarted` with the stop()/start() command guards. This QA
+    // screen streams CameraState into props at ~10Hz (CAMERA_STATE_THROTTLE_MS), so Fabric
+    // calls onAfterUpdateTransaction continuously. Once stop() started resetting
+    // `hasStarted = false` (so a later start() command actually restarts), the very next
+    // incidental prop-commit hit THIS block instead and silently auto-restarted the camera
+    // behind Stop's back — on a view whose previewView was never detached, which recursively
+    // re-triggers its own attach listener inside VisionCameraView.addViewFun() (SDK-side
+    // reentrancy bug) and freezes the main thread. Reproduced on-device: Stop → camera
+    // silently resumes within ~100ms; a later Stop during heavier re-render traffic instead
+    // hit the SDK recursion and hung the UI. Track "have we auto-started this view on
+    // mount" separately, per-view, so stop()'s hasStarted reset can never re-arm it.
+    private val hasAutoStartedOnMount = java.util.WeakHashMap<VisionCameraView, Boolean>()
+
     override fun onAfterUpdateTransaction(view: VisionCameraView) {
         super.onAfterUpdateTransaction(view)
 
         // Request layout to ensure proper sizing
         view.requestLayout()
 
-        // Only start camera once
-        if (visionCameraView == view && !hasStarted) {
+        // Camera Controls API (Phase 3) — one-shot replay of the current CameraState so
+        // `useCameraControls().state` is never stale-undefined on an already-running
+        // camera (§8 replay-on-attach). Relocated here from createViewInstance (Group D
+        // review fix #3): by the time onAfterUpdateTransaction runs, Fabric has assigned
+        // the view's real react tag and committed initial props, so this is the earliest
+        // point the emit is guaranteed to reach a mounted JS handler.
+        if (hasReplayedInitialCameraState[view] != true) {
+            hasReplayedInitialCameraState[view] = true
+            emitCameraState(view, view.currentCameraState(), bypassThrottle = true)
+        }
+
+        // Only auto-start the camera once per view (on initial mount) — gated on its OWN
+        // flag, deliberately NOT `hasStarted`, so an explicit stop() can never re-arm this
+        // block on the next incidental prop-commit (see hasAutoStartedOnMount comment).
+        if (visionCameraView == view && hasAutoStartedOnMount[view] != true) {
+            hasAutoStartedOnMount[view] = true
             hasStarted = true
             Log.d(TAG, "Starting camera for view id: ${view.id}")
 
@@ -172,6 +482,22 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
             currentCallback = null
         }
 
+        // Cancel any pending trailing-edge emit (Group D #1) — no point delivering a
+        // stale camera state to a view that's already been torn down.
+        cameraStateEmitStates[view]?.pendingTrailingRunnable?.let { mainHandler.removeCallbacks(it) }
+
+        // Camera Controls API (Phase 3) — unregister the state listener. The listener's
+        // callback can still be invoked concurrently/after this point; emitCameraState's
+        // own try/catch keeps that path safe.
+        cameraStateListenersByView[view]?.let {
+            try {
+                view.removeCameraStateListener(it)
+            } catch (e: Exception) {
+                Log.w(TAG, "removeCameraStateListener failed: ${e.message}")
+            }
+        }
+        cameraStateListenersByView.remove(view)
+
         // Stop the camera
         try {
             view.stopCamera()
@@ -198,7 +524,8 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
             "onRecognitionUpdate" to mapOf("registrationName" to "onRecognitionUpdate"),
             "onSharpnessScoreUpdate" to mapOf("registrationName" to "onSharpnessScoreUpdate"),
             "onBarcodeDetected" to mapOf("registrationName" to "onBarcodeDetected"),
-            "onBoundingBoxesUpdate" to mapOf("registrationName" to "onBoundingBoxesUpdate")
+            "onBoundingBoxesUpdate" to mapOf("registrationName" to "onBoundingBoxesUpdate"),
+            "onCameraStateChanged" to mapOf("registrationName" to "onCameraStateChanged")
         )
     }
 
@@ -207,13 +534,47 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
     @ReactProp(name = "enableFlash")
     override fun setEnableFlash(view: VisionCameraView, enabled: Boolean) {
         Log.d(TAG, "setEnableFlash: $enabled")
-        view.setFlashTurnedOn(enabled)
+        applyTorch(view, enabled)
     }
 
     @ReactProp(name = "zoomLevel")
     override fun setZoomLevel(view: VisionCameraView, level: Double) {
         Log.d(TAG, "setZoomLevel: $level")
-        view.setZoomRatio(level.toFloat())
+        applyZoomRatio(view, level.toFloat())
+    }
+
+    // Camera Controls API (Phase 3) — canonical props; enableFlash/zoomLevel above are
+    // deprecated aliases feeding the exact same applyTorch/applyZoomRatio path so
+    // reassertion-after-facing/lens-change (see reassertControlProps) works regardless
+    // of which prop name a consumer uses. Prop-collision precedence ("new wins") is a
+    // JS-layer concern (Group G / Task 12) — this layer only ever sees one value at a time.
+    @ReactProp(name = "torch", defaultBoolean = false)
+    override fun setTorch(view: VisionCameraView, enabled: Boolean) {
+        Log.d(TAG, "setTorch: $enabled")
+        applyTorch(view, enabled)
+    }
+
+    @ReactProp(name = "zoomRatio", defaultDouble = 1.0)
+    override fun setZoomRatio(view: VisionCameraView, ratio: Double) {
+        Log.d(TAG, "setZoomRatio: $ratio")
+        applyZoomRatio(view, ratio.toFloat())
+    }
+
+    @ReactProp(name = "focusMode")
+    override fun setFocusMode(view: VisionCameraView, mode: String?) {
+        Log.d(TAG, "setFocusMode: $mode")
+        applyFocusMode(view, mode)
+    }
+
+    @ReactProp(name = "pinnedLensId")
+    override fun setPinnedLensId(view: VisionCameraView, lensId: String?) {
+        Log.d(TAG, "setPinnedLensId: $lensId")
+        // Review fix (Group D #5) — normalize "" to null (unpin/Auto) at the source so
+        // downstream tracking (reassertControlProps' lastAppliedLensId comparison) never
+        // sees an empty-string/null mismatch loop.
+        val normalized = lensId?.takeIf { it.isNotEmpty() }
+        controlPropsFor(view).pinnedLensId = normalized
+        applyLensSelection(view, normalized)
     }
 
     @ReactProp(name = "scanMode")
@@ -312,10 +673,17 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
     @ReactProp(name = "cameraFacing")
     override fun setCameraFacing(view: VisionCameraView, facing: String?) {
         Log.d(TAG, "setCameraFacing: $facing")
-        // TODO: Implement camera facing/position switching for Android
-        // This will require updating the VisionSDK Android implementation
-        // to support CameraPosition enum (similar to iOS)
-        Log.d(TAG, "Camera facing prop received: $facing (Android implementation pending)")
+        val lensFace = when (facing?.lowercase()) {
+            "front" -> io.packagex.visionsdk.core.CameraLensFace.Front
+            else -> io.packagex.visionsdk.core.CameraLensFace.Back
+        }
+        // Review fix (parity #1) — track the raw prop value separately from
+        // cameraSettingsByView, which applyLensSelection's cross-facing pin path can
+        // overwrite; see restoreFacingFromProp / ControlPropsState.propCameraFacing.
+        controlPropsFor(view).propCameraFacing = lensFace
+        val updated = cameraSettingsFor(view).copy(cameraLensFace = lensFace)
+        cameraSettingsByView[view] = updated
+        view.setCameraSettings(updated)
     }
 
     @ReactProp(name = "frameSkip")
@@ -475,6 +843,15 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
             }
             "pauseDetection" -> pauseDetection(root)
             "resumeDetection" -> resumeDetection(root)
+            "setTorchEnabled" -> {
+                val enabled = args?.getBoolean(0) ?: false
+                setTorchEnabled(root, enabled)
+            }
+            "setFocusPoint" -> {
+                val x = (args?.getDouble(0) ?: 0.0).toFloat()
+                val y = (args?.getDouble(1) ?: 0.0).toFloat()
+                setFocusPoint(root, x, y)
+            }
             else -> Log.w(TAG, "Unknown command: $commandId")
         }
     }
@@ -486,6 +863,12 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
 
     override fun stop(view: VisionCameraView) {
         Log.d(TAG, "stop called")
+        // Bug fix (QA Group A #1) — hasStarted was only ever set (never cleared), so after
+        // an explicit stop() every subsequent start() command hit the guard below and
+        // silently no-opped forever. Reproduced on-device: Stop then Start logs "start
+        // called - camera already started or scheduled, ignoring" and the preview stays
+        // black. Reset it here so a stop+start cycle actually restarts the camera.
+        hasStarted = false
         view.stopCamera()
     }
 
@@ -511,17 +894,32 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
 
     override fun rescan(view: VisionCameraView) {
         Log.d(TAG, "rescan called")
+        // Bug fix (QA — torch/stop/rescan lockup): rescan() resumes scanning on a
+        // BOUND camera (its normal post-capture use). After an explicit stop() the
+        // camera is unbound, so view.rescan() can't rebuild it AND leaves the SDK's
+        // isCameraStarted() stuck true — which makes the next start() command hit its
+        // `hasStarted || isCameraStarted()` guard and silently no-op, wedging the
+        // camera black permanently. Reproduced on-device: torch on → Stop → Rescan →
+        // black, then Start logs "already started or scheduled, ignoring". When we're
+        // not started, treat Rescan as a fresh start instead (start() reasserts torch/
+        // zoom/focus on the RUNNING transition, so torch survives the cycle).
+        if (!hasStarted && !view.isCameraStarted()) {
+            Log.d(TAG, "rescan on a stopped camera — starting instead")
+            start(view)
+            return
+        }
         view.rescan()
     }
 
     override fun toggleFlash(view: VisionCameraView, enabled: Boolean) {
+        // Legacy alias -> torch (§8 "Command collision policy": toggleFlash -> torch).
         Log.d(TAG, "toggleFlash called with enabled: $enabled")
-        view.setFlashTurnedOn(enabled)
+        applyTorch(view, enabled)
     }
 
     override fun setZoom(view: VisionCameraView, level: Float) {
         Log.d(TAG, "setZoom called with level: $level")
-        view.setZoomRatio(level)
+        applyZoomRatio(view, level)
     }
 
     override fun pauseDetection(view: VisionCameraView) {
@@ -532,6 +930,20 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
     override fun resumeDetection(view: VisionCameraView) {
         Log.d(TAG, "resumeDetection called")
         view.resumeDetection()
+    }
+
+    // Camera Controls API (Phase 3) — setTorchEnabled is intentionally NOT named setTorch:
+    // the `torch` prop already generates setTorch(view, boolean) on
+    // VisionCameraViewManagerInterface; a same-named/same-erased-signature command method
+    // fails javac ("method already defined"). See src/specs/VisionCameraViewNativeComponent.ts.
+    override fun setTorchEnabled(view: VisionCameraView, enabled: Boolean) {
+        Log.d(TAG, "setTorchEnabled called with enabled: $enabled")
+        applyTorch(view, enabled)
+    }
+
+    override fun setFocusPoint(view: VisionCameraView, x: Float, y: Float) {
+        Log.d(TAG, "setFocusPoint called with x=$x y=$y")
+        view.setFocusPoint(x, y)
     }
 
     private fun parseColor(hex: String?, default: Int): Int {
@@ -681,12 +1093,9 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
         ) {
             Log.d(TAG, "onIndications: barcode=$barcodeDetected qr=$qrCodeDetected text=$textDetected doc=$documentDetected")
 
-            // Throttle recognition updates to avoid overwhelming the JS bridge
-            if (!shouldEmitThrottledEvent(lastRecognitionUpdateTime, RECOGNITION_UPDATE_THROTTLE_MS)) {
-                return
-            }
-            lastRecognitionUpdateTime = System.currentTimeMillis()
-
+            // Recognition updates emitted per native frame (throttle removed) so the
+            // JS-side FPS chip reflects the true processing rate. onBarcodeDetected was
+            // already unthrottled; the JS consumer must keep its per-event work cheap.
             val event = Arguments.createMap()
             event.putBoolean("text", textDetected)
             event.putBoolean("barcode", barcodeDetected)

--- a/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
+++ b/android/src/newarch/java/com/visionsdk/VisionCameraViewManager.kt
@@ -1091,7 +1091,9 @@ class VisionCameraViewManager(private val appContext: ReactApplicationContext) :
             textDetected: Boolean,
             documentDetected: Boolean
         ) {
-            Log.d(TAG, "onIndications: barcode=$barcodeDetected qr=$qrCodeDetected text=$textDetected doc=$documentDetected")
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "onIndications: barcode=$barcodeDetected qr=$qrCodeDetected text=$textDetected doc=$documentDetected")
+            }
 
             // Recognition updates emitted per native frame (throttle removed) so the
             // JS-side FPS chip reflects the true processing rate. onBarcodeDetected was

--- a/android/src/newarch/java/com/visionsdk/VisionSdkModule.kt
+++ b/android/src/newarch/java/com/visionsdk/VisionSdkModule.kt
@@ -1522,6 +1522,62 @@ class VisionSdkModule(reactContext: ReactApplicationContext) :
         }
     }
 
+    // Camera Controls API (Phase 3, Group F) — enum-string mapping mirrors
+    // VisionCameraViewManager.cameraStateToMap's facing mapping exactly. LensKind has no
+    // equivalent in the view layer (CameraState doesn't carry per-lens kind), so this is a
+    // new mapping — kept camelCase to match the JS `Lens.kind` union (NOT `.name.lowercase()`,
+    // which would yield "ultra_wide" instead of "ultraWide").
+    private fun lensKindToJsString(kind: io.packagex.visionsdk.camera.core.LensKind): String =
+        when (kind) {
+            io.packagex.visionsdk.camera.core.LensKind.ULTRA_WIDE -> "ultraWide"
+            io.packagex.visionsdk.camera.core.LensKind.WIDE -> "wide"
+            io.packagex.visionsdk.camera.core.LensKind.TELEPHOTO -> "telephoto"
+            else -> "unknown"
+        }
+
+    @ReactMethod
+    override fun getCameraCapabilities(promise: Promise) {
+        try {
+            val capabilities = io.packagex.visionsdk.camera.core.CameraCapabilities.snapshot(reactApplicationContext)
+            val facings = listOf(
+                io.packagex.visionsdk.camera.core.LensFacing.BACK to "back",
+                io.packagex.visionsdk.camera.core.LensFacing.FRONT to "front"
+            )
+            val lensesJson = JSONArray()
+            val zoomStopsJson = JSONObject()
+            val hasTorchJson = JSONObject()
+            val supportsFocusPointJson = JSONObject()
+            for ((facing, facingName) in facings) {
+                capabilities.lenses(facing).forEach { lens ->
+                    lensesJson.put(JSONObject().apply {
+                        put("id", lens.id)
+                        put("kind", lensKindToJsString(lens.kind))
+                        put("facing", facingName)
+                        put("minZoomRatio", lens.minZoomRatio.toDouble())
+                        put("maxZoomRatio", lens.maxZoomRatio.toDouble())
+                        put("zoomSwitchPoints", JSONArray(lens.zoomSwitchPoints.map { it.toDouble() }))
+                        put("hasFlash", lens.hasFlash)
+                        put("isLogical", lens.isLogical)
+                        put("isPinnable", lens.isPinnable)
+                    })
+                }
+                zoomStopsJson.put(facingName, JSONArray(capabilities.zoomStops(facing).map { it.toDouble() }))
+                hasTorchJson.put(facingName, capabilities.hasTorch(facing))
+                supportsFocusPointJson.put(facingName, capabilities.supportsFocusPoint(facing))
+            }
+            val result = JSONObject().apply {
+                put("lenses", lensesJson)
+                put("zoomStops", zoomStopsJson)
+                put("hasTorch", hasTorchJson)
+                put("supportsFocusPoint", supportsFocusPointJson)
+            }
+            promise.resolve(result.toString())
+        } catch (e: Exception) {
+            Log.e(TAG, "❌ getCameraCapabilities failed", e)
+            promise.reject("CAPABILITIES_ERROR", e.message, e)
+        }
+    }
+
     @ReactMethod
     override fun addListener(eventName: String) {
         // Required for TurboModule event emitters

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -57,8 +57,8 @@ target 'VisionSdkExample' do
 
   # VisionSDK from CocoaPods trunk. Matches the deps declared by the
   # react-native-vision-sdk podspec; pinned explicitly here for clarity.
-  pod 'VisionSDK', '= 2.3.14'
-  pod 'VisionSDK/Dimensioning', '= 2.3.14'
+  pod 'VisionSDK', '= 2.4.0'
+  pod 'VisionSDK/Dimensioning', '= 2.4.0'
 
   use_react_native!(
     :path => config[:reactNativePath],

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.82.1):
     - hermes-engine/Pre-built (= 0.82.1)
   - hermes-engine/Pre-built (0.82.1)
-  - PostHog (3.66.1)
+  - PostHog (3.69.0)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -1870,7 +1870,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-vision-sdk (3.8.0):
+  - react-native-vision-sdk (3.10.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -1897,8 +1897,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-    - VisionSDK (= 2.3.14)
-    - VisionSDK/Dimensioning (= 2.3.14)
+    - VisionSDK (= 2.4.0)
+    - VisionSDK/Dimensioning (= 2.4.0)
     - Yoga
   - React-NativeModulesApple (0.82.1):
     - boost
@@ -2849,10 +2849,10 @@ PODS:
     - SocketRocket
     - Yoga
   - SocketRocket (0.7.1)
-  - VisionSDK (2.3.14):
-    - VisionSDK/Core (= 2.3.14)
-  - VisionSDK/Core (2.3.14)
-  - VisionSDK/Dimensioning (2.3.14):
+  - VisionSDK (2.4.0):
+    - VisionSDK/Core (= 2.4.0)
+  - VisionSDK/Core (2.4.0)
+  - VisionSDK/Dimensioning (2.4.0):
     - PostHog (~> 3.0)
     - VisionSDK/Core
   - Yoga (0.0.0)
@@ -2942,8 +2942,8 @@ DEPENDENCIES:
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - RNWorklets (from `../node_modules/react-native-worklets`)
   - SocketRocket (~> 0.7.1)
-  - VisionSDK (= 2.3.14)
-  - VisionSDK/Dimensioning (= 2.3.14)
+  - VisionSDK (= 2.4.0)
+  - VisionSDK/Dimensioning (= 2.4.0)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -3129,7 +3129,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 273e30e7fb618279934b0b95ffab60ecedb7acf5
-  PostHog: f906c839bed59a21eb853587afc7fc303b492382
+  PostHog: d897f101fb9bf869fc76a6face2484bc2a9b0d30
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: f17e2ebc07876ca9ab8eb6e4b0a4e4647497ae3a
   RCTRequired: e2c574c1b45231f7efb0834936bd609d75072b63
@@ -3164,7 +3164,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 06d59c448da7e34eb05b3fb2189e12f6a30fec57
   React-microtasksnativemodule: d1ee999dc9052e23f6488b730fa2d383a4ea40e5
   react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
-  react-native-vision-sdk: 4191e438a696f6769d31469aed481586dd6b8ce9
+  react-native-vision-sdk: 96c1db30f11091df977ea2d8d9d710dd4d1e51d5
   React-NativeModulesApple: 46690a0fe94ec28fc6fc686ec797b911d251ded0
   React-oscompat: 95875e81f5d4b3c7b2c888d5bd2c9d83450d8bdb
   React-perflogger: 2e229bf33e42c094fd64516d89ec1187a2b79b5b
@@ -3206,9 +3206,9 @@ SPEC CHECKSUMS:
   RNVectorIcons: 791f13226ec4a3fd13062eda9e892159f0981fae
   RNWorklets: ab618bf7d1c7fd2cb793b9f0f39c3e29274b3ebf
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  VisionSDK: cf422ee36903b889ef72d261d40aaf02abe475de
+  VisionSDK: 08e4af59c97f82ad610cfdcc39c6bc5439a70aeb
   Yoga: 689c8e04277f3ad631e60fe2a08e41d411daf8eb
 
-PODFILE CHECKSUM: e074ac5ec1c256663ea5a2e96c7de4be8d3100c0
+PODFILE CHECKSUM: bde5a8048449bea67530fe70971cc6ccc5f98697
 
 COCOAPODS: 1.16.2

--- a/example/ios/VisionSdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/VisionSdkExample.xcodeproj/project.pbxproj
@@ -489,6 +489,7 @@
 				PRODUCT_NAME = VisionSdkExample;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -517,6 +518,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = VisionSdkExample;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -14,6 +14,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { ScannerScreen } from './screens/ScannerScreen';
 import { DimensioningScreen } from './screens/DimensioningScreen';
+import { CameraControlsQAScreen } from './screens/CameraControlsQAScreen';
 
 const Stack = createNativeStackNavigator();
 
@@ -27,6 +28,13 @@ const App = () => {
         >
           <Stack.Screen name="ScannerScreen" component={ScannerScreen} />
           <Stack.Screen name="DimensioningScreen" component={DimensioningScreen} />
+          <Stack.Screen
+            name="CameraControlsQAScreen"
+            component={CameraControlsQAScreen}
+            // The iOS interactive swipe-back competes with the zoom slider's
+            // left-edge drags — back out via the header arrow instead.
+            options={{ gestureEnabled: false }}
+          />
         </Stack.Navigator>
       </NavigationContainer>
     </SafeAreaProvider>

--- a/example/src/screens/CameraControlsQAScreen.tsx
+++ b/example/src/screens/CameraControlsQAScreen.tsx
@@ -1,0 +1,603 @@
+/**
+ * CameraControlsQAScreen — manual on-device test harness for the Phase-3
+ * Camera Controls API (`useCameraControls()` + the new `<VisionCamera>`
+ * props/commands). RN equivalent of the native `CameraCoreTestScreen`
+ * (Android) / `CameraControlsQAView` (iOS) harnesses.
+ *
+ * Every control below drives the PUBLIC surface only:
+ *   - `useCameraControls()` hook (`camera.setZoom`, `camera.setTorch`,
+ *     `camera.setFocusPoint`, `camera.state`, `camera.capabilities`)
+ *   - `<VisionCamera>` props (`cameraFacing`, `focusMode`, `pinnedLensId`)
+ *   - the `VisionCameraRefProps` ref (`start`/`stop`/`rescan`)
+ *
+ * No internal wrappers are touched.
+ */
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  Alert,
+  Animated,
+  PanResponder,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import MCIcon from 'react-native-vector-icons/MaterialCommunityIcons';
+import { PERMISSIONS, RESULTS, request } from 'react-native-permissions';
+import { Platform } from 'react-native';
+import { VisionCamera } from '../../../src/VisionCamera';
+import type {
+  CameraFacing,
+  VisionCameraRefProps,
+} from '../../../src/VisionCameraTypes';
+import type { FocusMode } from '../../../src/types';
+import { useCameraControls } from '../../../src/camera-controls/useCameraControls';
+import { ZoomPills } from '../components/ZoomPills';
+import { SegmentedControl } from '../components/SegmentedControl';
+import { theme } from '../theme';
+
+interface Props {
+  navigation: { goBack: () => void };
+}
+
+const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
+
+// ---------------------------------------------------------------------------
+// RatioSlider — bare PanResponder-driven slider (mirrors ScannerScreen's
+// ZoomSlider; kept local since this screen's data flow differs — it drives
+// camera.setZoom() imperatively rather than a local zoomLevel prop binding).
+// ---------------------------------------------------------------------------
+interface RatioSliderProps {
+  value: number;
+  min: number;
+  max: number;
+  onValueChange: (v: number) => void;
+  /** Called on drag start/end so the parent ScrollView can pause scrolling —
+   * without this, the ScrollView's own pan recognizer competes for the gesture
+   * on iOS and the drag feels janky/steals mid-swipe. */
+  onDraggingChange?: (dragging: boolean) => void;
+}
+
+function RatioSlider({ value, min, max, onValueChange, onDraggingChange }: RatioSliderProps) {
+  const trackRef = useRef<View>(null);
+  const widthRef = useRef(200);
+  const trackLeftRef = useRef(0); // track's absolute screen-x (left edge)
+  // Thumb driven by an Animated.Value updated imperatively from the PanResponder
+  // — no React re-render per move.
+  const thumbPct = useRef(new Animated.Value(0)).current;
+  const draggingRef = useRef(false);
+  // PanResponder is created once, so it MUST read the latest min/max/onValueChange
+  // from a ref — they change when the camera leaves idle (1/1 -> e.g. 0.67/8).
+  const cfgRef = useRef({ min, max, onValueChange, onDraggingChange });
+  cfgRef.current = { min, max, onValueChange, onDraggingChange };
+  // Range FROZEN at drag-start so a mid-drag lens auto-switch (which re-reports
+  // min/max) can't shift the mapping under the finger.
+  const dragRangeRef = useRef<{ lo: number; hi: number } | null>(null);
+
+  // Map an ABSOLUTE screen x (gestureState.moveX) to a fraction of the track.
+  // Using the absolute gesture coord + the measured track-left — NOT
+  // e.nativeEvent.locationX — is the fix for the knob "jumping": locationX is
+  // reported relative to whichever child (fill bar / thumb) sits under the
+  // finger, so it lurches discontinuously as the finger crosses them mid-drag.
+  function applyAtAbs(absX: number) {
+    const r = dragRangeRef.current ?? { lo: cfgRef.current.min, hi: cfgRef.current.max };
+    const span = Math.max(r.hi - r.lo, 0.001);
+    const pct = clamp01((absX - trackLeftRef.current) / widthRef.current);
+    thumbPct.setValue(pct); // move the thumb imperatively — no re-render
+    // Continuous — no rounding — smooth zoom that reaches the exact endpoints.
+    cfgRef.current.onValueChange(r.lo + pct * span);
+  }
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      // NEVER yield the gesture to the enclosing ScrollView mid-drag — without
+      // this the ScrollView's pan recognizer steals the responder on small
+      // vertical drift and the drag stutters/dies (iOS especially).
+      onPanResponderTerminationRequest: () => false,
+      onPanResponderGrant: (_e, g) => {
+        draggingRef.current = true;
+        cfgRef.current.onDraggingChange?.(true);
+        dragRangeRef.current = { lo: cfgRef.current.min, hi: cfgRef.current.max };
+        applyAtAbs(g.x0);
+      },
+      onPanResponderMove: (_e, g) => applyAtAbs(g.moveX),
+      onPanResponderRelease: () => {
+        draggingRef.current = false;
+        dragRangeRef.current = null;
+        cfgRef.current.onDraggingChange?.(false);
+      },
+      onPanResponderTerminate: () => {
+        draggingRef.current = false;
+        dragRangeRef.current = null;
+        cfgRef.current.onDraggingChange?.(false);
+      },
+    })
+  ).current;
+
+  // When NOT dragging, follow live state; skipped mid-drag so the finger-driven
+  // thumb is never fought by the throttle-lagging state.
+  React.useEffect(() => {
+    if (draggingRef.current) return;
+    thumbPct.setValue(clamp01((value - min) / Math.max(max - min, 0.001)));
+  }, [value, min, max, thumbPct]);
+
+  const widthStyle = thumbPct.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0%', '100%'],
+  });
+
+  return (
+    <View
+      ref={trackRef}
+      style={sliderStyles.track}
+      onLayout={(e) => {
+        widthRef.current = e.nativeEvent.layout.width;
+        // Absolute left is stable under vertical scroll, so measuring once here
+        // is enough to map screen-x → track fraction.
+        trackRef.current?.measureInWindow((x) => {
+          trackLeftRef.current = x;
+        });
+      }}
+      {...panResponder.panHandlers}
+    >
+      <Animated.View style={[sliderStyles.fill, { width: widthStyle }]} />
+      <Animated.View style={[sliderStyles.thumb, { left: widthStyle }]} />
+    </View>
+  );
+}
+
+const sliderStyles = StyleSheet.create({
+  track: {
+    height: 4,
+    backgroundColor: theme.colors.divider,
+    borderRadius: 2,
+    justifyContent: 'center',
+    marginVertical: 16,
+  },
+  fill: {
+    height: 4,
+    backgroundColor: theme.colors.accent,
+    borderRadius: 2,
+  },
+  thumb: {
+    position: 'absolute',
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    backgroundColor: '#fff',
+    marginLeft: -10,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.4,
+    shadowRadius: 3,
+    elevation: 4,
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Small building blocks
+// ---------------------------------------------------------------------------
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>{title}</Text>
+      {children}
+    </View>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.row}>
+      <Text style={styles.rowLabel}>{label}</Text>
+      <Text style={styles.rowValue} selectable numberOfLines={1}>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CameraControlsQAScreen
+// ---------------------------------------------------------------------------
+export function CameraControlsQAScreen({ navigation }: Props) {
+  const cameraRef = useRef<VisionCameraRefProps>(null);
+  const camera = useCameraControls();
+
+  // Composes cameraRef (start/stop/rescan) with camera.ref (state/capabilities
+  // wiring) — same pattern as ScannerScreen's setVisionCameraRef.
+  const setVisionCameraRef = useCallback(
+    (instance: VisionCameraRefProps | null) => {
+      (cameraRef as React.MutableRefObject<VisionCameraRefProps | null>).current = instance;
+      // `camera.ref` is a real callback ref (see useCameraControls.ts).
+      camera.ref(instance);
+    },
+    [camera.ref]
+  );
+
+  const [hasPermission, setHasPermission] = useState(false);
+  // Paused while the zoom slider is being dragged so the ScrollView's pan
+  // recognizer can't compete with the slider's PanResponder (iOS jank fix).
+  const [scrollEnabled, setScrollEnabled] = useState(true);
+  const [facing, setFacing] = useState<CameraFacing>('back');
+  const [focusMode, setFocusMode] = useState<FocusMode>('continuous');
+  const [pinnedLensId, setPinnedLensId] = useState<string | undefined>(undefined);
+  const [lastFocusTap, setLastFocusTap] = useState<{ x: number; y: number } | null>(null);
+  const previewSize = useRef({ width: 0, height: 0 });
+
+  React.useEffect(() => {
+    const perm = Platform.OS === 'ios' ? PERMISSIONS.IOS.CAMERA : PERMISSIONS.ANDROID.CAMERA;
+    request(perm).then((result) => {
+      setHasPermission(result === RESULTS.GRANTED);
+      if (result !== RESULTS.GRANTED) {
+        Alert.alert('Camera Permission Required', 'Please enable camera access in Settings.');
+      }
+    });
+  }, []);
+
+  const state = camera.state;
+  const capabilities = camera.capabilities;
+
+  const zoomStops = capabilities?.zoomStops?.[facing] ?? [];
+  const minZoom = state?.minZoomRatio ?? 1;
+  const maxZoom = state?.maxZoomRatio ?? 4;
+  const currentZoom = state?.zoomRatio ?? 1;
+  // Stringify only when capabilities actually change — not on every ~10Hz state
+  // update. Re-serializing this on each render adds JS-thread work that competes
+  // with an in-progress zoom drag.
+  const capabilitiesJson = React.useMemo(
+    () => (capabilities ? JSON.stringify(capabilities, null, 2) : 'Loading…'),
+    [capabilities]
+  );
+
+  // Pin/facing coherence (both platforms): natively, a cross-facing pin wins and
+  // switches the camera's facing out-of-band from the cameraFacing prop — so JS
+  // state must follow the pin, and an explicit facing choice must drop a pin from
+  // the other facing (otherwise the native reassert re-pins and yanks it back).
+  const handlePinLens = useCallback((lensId: string, lensFacing: string) => {
+    setPinnedLensId(lensId);
+    setFacing(lensFacing === 'front' ? 'front' : 'back');
+  }, []);
+
+  const handleFacingSelect = useCallback(
+    (next: CameraFacing) => {
+      setFacing(next);
+      const pinned = capabilities?.lenses.find((l) => l.id === pinnedLensId);
+      if (pinned && pinned.facing !== next) {
+        setPinnedLensId(undefined);
+      }
+    },
+    [capabilities, pinnedLensId]
+  );
+
+  const handlePreviewTap = useCallback(
+    (locationX: number, locationY: number) => {
+      const { width, height } = previewSize.current;
+      if (width <= 0 || height <= 0) return;
+      const x = clamp01(locationX / width);
+      const y = clamp01(locationY / height);
+      setLastFocusTap({ x, y });
+      camera.setFocusPoint(x, y);
+    },
+    [camera]
+  );
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backBtn}>
+          <MCIcon name="arrow-left" size={22} color={theme.colors.textPrimary} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Camera Controls QA</Text>
+        <View style={styles.backBtn} />
+      </View>
+
+      {/* ── Camera preview (tap-to-focus surface) ── */}
+      <View
+        style={styles.previewContainer}
+        onLayout={(e) => {
+          previewSize.current = {
+            width: e.nativeEvent.layout.width,
+            height: e.nativeEvent.layout.height,
+          };
+        }}
+        onStartShouldSetResponder={() => true}
+        onResponderRelease={(e) =>
+          handlePreviewTap(e.nativeEvent.locationX, e.nativeEvent.locationY)
+        }
+      >
+        {hasPermission ? (
+          <VisionCamera
+            ref={setVisionCameraRef}
+            style={StyleSheet.absoluteFill}
+            scanMode="barcode"
+            cameraFacing={facing}
+            focusMode={focusMode}
+            pinnedLensId={pinnedLensId}
+            onCameraStateChanged={camera.onCameraStateChanged}
+            onError={(err) => Alert.alert('Camera Error', err.message)}
+          />
+        ) : (
+          <View style={styles.noPerm}>
+            <Text style={styles.noPermText}>Camera permission required</Text>
+          </View>
+        )}
+      </View>
+
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.scrollContent}
+        scrollEnabled={scrollEnabled}
+      >
+        {/* ── Live readout strip ── */}
+        <Section title="Live State">
+          <View style={styles.statusHeader}>
+            <View
+              style={[
+                styles.dot,
+                {
+                  backgroundColor: state?.isPreviewActive
+                    ? theme.colors.success
+                    : theme.colors.error,
+                },
+              ]}
+            />
+            <Text style={styles.statusText}>{state?.status ?? 'unknown'}</Text>
+          </View>
+          <Row label="facing" value={state?.facing ?? '—'} />
+          <Row label="activeLensId" value={state?.activeLensId ?? '—'} />
+          <Row
+            label="zoomRatio"
+            value={
+              state
+                ? `${state.zoomRatio.toFixed(2)}  (min ${state.minZoomRatio.toFixed(2)} / max ${state.maxZoomRatio.toFixed(2)})`
+                : '—'
+            }
+          />
+          <Row label="torchEnabled" value={state ? String(state.torchEnabled) : '—'} />
+          <Row label="focusMode" value={state?.focusMode ?? '—'} />
+          {state?.warningCode ? (
+            <Row
+              label="warning"
+              value={`${state.warningCode}${state.warningMessage ? `: ${state.warningMessage}` : ''}`}
+            />
+          ) : null}
+          {state?.errorCode ? (
+            <Row
+              label="error"
+              value={`${state.errorCode}${state.errorMessage ? `: ${state.errorMessage}` : ''}`}
+            />
+          ) : null}
+        </Section>
+
+        {/* ── Zoom ── */}
+        <Section title="Zoom">
+          <RatioSlider
+            value={currentZoom}
+            min={minZoom}
+            max={maxZoom}
+            onValueChange={(v) => camera.setZoom(v)}
+            onDraggingChange={(dragging) => setScrollEnabled(!dragging)}
+          />
+          <Text style={styles.helperText}>{currentZoom.toFixed(2)}x</Text>
+          {zoomStops.length > 0 ? (
+            <ZoomPills presets={zoomStops} current={currentZoom} onSelect={camera.setZoom} />
+          ) : (
+            <Text style={styles.helperTextMuted}>No zoom stops reported for {facing}.</Text>
+          )}
+        </Section>
+
+        {/* ── Torch ── */}
+        <Section title="Torch">
+          <TouchableOpacity
+            style={[styles.toggleBtn, state?.torchEnabled && styles.toggleBtnActive]}
+            onPress={() => camera.setTorch(!(state?.torchEnabled ?? false))}
+          >
+            <Text style={[styles.toggleBtnText, state?.torchEnabled && styles.toggleBtnTextActive]}>
+              {state?.torchEnabled ? 'Torch ON' : 'Torch OFF'}
+            </Text>
+          </TouchableOpacity>
+        </Section>
+
+        {/* ── Facing ── */}
+        <Section title="Facing">
+          <SegmentedControl<CameraFacing>
+            segments={[
+              { label: 'Back', value: 'back' },
+              { label: 'Front', value: 'front' },
+            ]}
+            selected={facing}
+            onSelect={handleFacingSelect}
+          />
+        </Section>
+
+        {/* ── Focus mode ── */}
+        <Section title="Focus Mode">
+          <SegmentedControl<FocusMode>
+            segments={[
+              { label: 'Continuous', value: 'continuous' },
+              { label: 'Single', value: 'single' },
+              { label: 'Locked', value: 'locked' },
+            ]}
+            selected={focusMode}
+            onSelect={setFocusMode}
+          />
+        </Section>
+
+        {/* ── Tap-to-focus ── */}
+        <Section title="Tap-to-Focus">
+          <Text style={styles.helperTextMuted}>
+            Tap anywhere on the preview above to call setFocusPoint(x, y) with
+            view-normalized coordinates.
+          </Text>
+          <Row
+            label="last tap"
+            value={lastFocusTap ? `(${lastFocusTap.x.toFixed(2)}, ${lastFocusTap.y.toFixed(2)})` : '—'}
+          />
+        </Section>
+
+        {/* ── Lens picker ── */}
+        <Section title="Lenses">
+          <TouchableOpacity
+            style={[styles.lensRow, pinnedLensId === undefined && styles.lensRowActive]}
+            onPress={() => setPinnedLensId(undefined)}
+          >
+            <Text style={styles.lensRowText}>Auto (no pin)</Text>
+          </TouchableOpacity>
+          {(capabilities?.lenses ?? []).map((lens) => (
+            <TouchableOpacity
+              key={lens.id}
+              style={[styles.lensRow, pinnedLensId === lens.id && styles.lensRowActive]}
+              disabled={!lens.isPinnable}
+              onPress={() => handlePinLens(lens.id, lens.facing)}
+            >
+              <Text style={[styles.lensRowText, !lens.isPinnable && styles.lensRowTextDisabled]}>
+                {lens.id} · {lens.kind} · {lens.facing}
+                {lens.isPinnable ? '' : ' (not pinnable)'}
+                {state?.activeLensId === lens.id ? '  ← active' : ''}
+              </Text>
+            </TouchableOpacity>
+          ))}
+          {!capabilities ? (
+            <Text style={styles.helperTextMuted}>Loading capabilities…</Text>
+          ) : null}
+        </Section>
+
+        {/* ── Capabilities panel ── */}
+        <Section title="Capabilities (raw)">
+          <ScrollView horizontal>
+            <Text style={styles.capabilitiesJson} selectable>
+              {capabilitiesJson}
+            </Text>
+          </ScrollView>
+        </Section>
+
+        {/* ── Start / Stop / Rescan ── */}
+        <Section title="Session">
+          <View style={styles.sessionRow}>
+            <TouchableOpacity
+              style={styles.sessionBtn}
+              onPress={() => cameraRef.current?.start()}
+            >
+              <Text style={styles.sessionBtnText}>Start</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.sessionBtn}
+              onPress={() => cameraRef.current?.stop()}
+            >
+              <Text style={styles.sessionBtnText}>Stop</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.sessionBtn}
+              onPress={() => cameraRef.current?.rescan()}
+            >
+              <Text style={styles.sessionBtnText}>Rescan</Text>
+            </TouchableOpacity>
+          </View>
+        </Section>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: theme.colors.bg },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.sm,
+  },
+  backBtn: { width: 36, height: 36, alignItems: 'center', justifyContent: 'center' },
+  headerTitle: {
+    color: theme.colors.textPrimary,
+    fontSize: theme.fontSize.lg,
+    fontWeight: theme.fontWeight.bold,
+  },
+  previewContainer: {
+    height: 220,
+    backgroundColor: theme.colors.bgDeep,
+    marginHorizontal: theme.spacing.md,
+    borderRadius: theme.radii.lg,
+    overflow: 'hidden',
+  },
+  noPerm: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  noPermText: { color: theme.colors.textMuted, fontSize: theme.fontSize.sm },
+  scroll: { flex: 1, marginTop: theme.spacing.md },
+  scrollContent: { paddingHorizontal: theme.spacing.md, paddingBottom: theme.spacing.huge },
+  section: {
+    backgroundColor: theme.colors.bgCard,
+    borderRadius: theme.radii.lg,
+    padding: theme.spacing.lg,
+    marginBottom: theme.spacing.md,
+  },
+  sectionTitle: {
+    color: theme.colors.textSecondary,
+    fontSize: theme.fontSize.xs,
+    fontWeight: theme.fontWeight.bold,
+    textTransform: 'uppercase',
+    letterSpacing: theme.letterSpacing.wide,
+    marginBottom: theme.spacing.sm,
+  },
+  statusHeader: { flexDirection: 'row', alignItems: 'center', marginBottom: theme.spacing.sm },
+  dot: { width: 10, height: 10, borderRadius: 5, marginRight: 8 },
+  statusText: {
+    color: theme.colors.textPrimary,
+    fontSize: theme.fontSize.md,
+    fontWeight: theme.fontWeight.semibold,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 4,
+  },
+  rowLabel: { color: theme.colors.textMuted, fontSize: theme.fontSize.sm },
+  rowValue: {
+    color: theme.colors.textPrimary,
+    fontSize: theme.fontSize.sm,
+    fontWeight: theme.fontWeight.medium,
+    marginLeft: theme.spacing.md,
+    flexShrink: 1,
+    textAlign: 'right',
+  },
+  helperText: { color: theme.colors.textPrimary, fontSize: theme.fontSize.sm, marginBottom: 8 },
+  helperTextMuted: { color: theme.colors.textMuted, fontSize: theme.fontSize.xs },
+  toggleBtn: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: theme.spacing.lg,
+    paddingVertical: theme.spacing.sm,
+    borderRadius: theme.radii.lg,
+    backgroundColor: theme.colors.bgCardStrong,
+  },
+  toggleBtnActive: { backgroundColor: theme.colors.accent },
+  toggleBtnText: { color: theme.colors.textPrimary, fontWeight: theme.fontWeight.semibold },
+  toggleBtnTextActive: { color: theme.colors.textOnAccent },
+  lensRow: {
+    paddingVertical: theme.spacing.sm,
+    paddingHorizontal: theme.spacing.md,
+    borderRadius: theme.radii.md,
+    marginBottom: 4,
+  },
+  lensRowActive: { backgroundColor: theme.colors.accentDim },
+  lensRowText: { color: theme.colors.textPrimary, fontSize: theme.fontSize.sm },
+  lensRowTextDisabled: { color: theme.colors.textMuted },
+  capabilitiesJson: {
+    color: theme.colors.textSecondary,
+    fontSize: theme.fontSize.xxs,
+    fontFamily: 'Menlo',
+  },
+  sessionRow: { flexDirection: 'row', gap: 10 },
+  sessionBtn: {
+    flex: 1,
+    paddingVertical: theme.spacing.sm,
+    borderRadius: theme.radii.lg,
+    backgroundColor: theme.colors.bgCardStrong,
+    alignItems: 'center',
+  },
+  sessionBtnText: { color: theme.colors.textPrimary, fontWeight: theme.fontWeight.semibold },
+});

--- a/example/src/screens/ScannerScreen.tsx
+++ b/example/src/screens/ScannerScreen.tsx
@@ -26,6 +26,7 @@ import React, {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from 'react';
 import {
   Alert,
@@ -59,6 +60,7 @@ import type {
   VisionCameraDetectedCodeBoundingBox,
 } from '../../../src/VisionCameraTypes';
 import { VisionCore } from '../../../src';
+import { useCameraControls } from '../../../src/camera-controls/useCameraControls';
 import { SettingsModal } from './SettingsModal';
 import { ResultScreen } from './ResultScreen';
 import { theme } from '../theme';
@@ -113,6 +115,10 @@ const OCR_MODULE_OPTIONS: { label: string; type: OCRModuleType }[] = [
   { label: 'Doc. Classification', type: 'document_classification' },
 ];
 
+// Fallback zoom-pill stops for while `VisionCore.getCameraCapabilities()`
+// hasn't resolved yet (or reports no stops for the active facing) — the
+// live stops come from `camera.capabilities.zoomStops[cameraFacing]` below
+// (spec §9 "example-app zoom-pill migration to zoomStops").
 const ZOOM_PRESETS = [0.6, 1.0, 2.0];
 const DEFAULT_ZOOM = 1.0;
 const SHARPNESS_THRESHOLD = 0.5;
@@ -536,40 +542,82 @@ interface ZoomSliderProps {
 }
 
 function ZoomSlider({ value, min, max, onValueChange }: ZoomSliderProps) {
+  const trackRef = useRef<View>(null);
   const sliderWidthRef = useRef(200);
+  const trackLeftRef = useRef(0); // track's absolute screen-x (left edge)
+  // Thumb driven by an Animated.Value updated imperatively from the PanResponder
+  // — no React re-render per move.
+  const thumbPct = useRef(new Animated.Value(0)).current;
+  const draggingRef = useRef(false);
+  // PanResponder is created once; read latest min/max/callback from a ref so a
+  // stale closure can't freeze the range (min/max go 1/1 -> e.g. 0.67/8 once the
+  // camera leaves idle).
+  const cfgRef = useRef({ min, max, onValueChange });
+  cfgRef.current = { min, max, onValueChange };
+  // Range frozen at drag-start so a mid-drag lens auto-switch can't shift the
+  // mapping under the finger.
+  const dragRangeRef = useRef<{ lo: number; hi: number } | null>(null);
+
+  // Map an ABSOLUTE screen x (gestureState) to a track fraction. Using the
+  // absolute gesture coord + measured track-left — NOT e.nativeEvent.locationX —
+  // is the fix for the knob "jumping": locationX is reported relative to whichever
+  // child (fill/thumb) sits under the finger and lurches as the finger crosses them.
+  function applyAtAbs(absX: number) {
+    const r = dragRangeRef.current ?? { lo: cfgRef.current.min, hi: cfgRef.current.max };
+    const span = Math.max(r.hi - r.lo, 0.001);
+    const pct = Math.max(0, Math.min(1, (absX - trackLeftRef.current) / sliderWidthRef.current));
+    thumbPct.setValue(pct); // move thumb imperatively — no re-render
+    // Continuous — no rounding — smooth zoom that reaches the exact endpoints.
+    cfgRef.current.onValueChange(r.lo + pct * span);
+  }
+
   const panResponder = useRef(
     PanResponder.create({
       onStartShouldSetPanResponder: () => true,
       onMoveShouldSetPanResponder: () => true,
-      onPanResponderGrant: (e) => {
-        const { locationX } = e.nativeEvent;
-        const pct = Math.max(0, Math.min(1, locationX / sliderWidthRef.current));
-        const z = min + pct * (max - min);
-        onValueChange(Math.round(z * 10) / 10);
+      onPanResponderGrant: (_e, g) => {
+        draggingRef.current = true;
+        dragRangeRef.current = { lo: cfgRef.current.min, hi: cfgRef.current.max };
+        applyAtAbs(g.x0);
       },
-      onPanResponderMove: (e) => {
-        const { locationX } = e.nativeEvent;
-        const pct = Math.max(0, Math.min(1, locationX / sliderWidthRef.current));
-        const z = min + pct * (max - min);
-        onValueChange(Math.round(z * 10) / 10);
+      onPanResponderMove: (_e, g) => applyAtAbs(g.moveX),
+      onPanResponderRelease: () => {
+        draggingRef.current = false;
+        dragRangeRef.current = null;
+      },
+      onPanResponderTerminate: () => {
+        draggingRef.current = false;
+        dragRangeRef.current = null;
       },
     })
   ).current;
 
-  const pct = (value - min) / (max - min);
+  // When NOT dragging, follow live value; skipped mid-drag so the finger-driven
+  // thumb is never fought by a lagging value.
+  useEffect(() => {
+    if (draggingRef.current) return;
+    thumbPct.setValue(Math.max(0, Math.min(1, (value - min) / Math.max(max - min, 0.001))));
+  }, [value, min, max, thumbPct]);
+
+  const widthStyle = thumbPct.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0%', '100%'],
+  });
 
   return (
     <View
+      ref={trackRef}
       style={zsStyles.track}
       onLayout={(e) => {
         sliderWidthRef.current = e.nativeEvent.layout.width;
+        trackRef.current?.measureInWindow((x) => {
+          trackLeftRef.current = x;
+        });
       }}
       {...panResponder.panHandlers}
     >
-      <View style={[zsStyles.fill, { width: `${pct * 100}%` as `${number}%` }]} />
-      <View
-        style={[zsStyles.thumb, { left: `${pct * 100}%` as `${number}%` }]}
-      />
+      <Animated.View style={[zsStyles.fill, { width: widthStyle }]} />
+      <Animated.View style={[zsStyles.thumb, { left: widthStyle }]} />
     </View>
   );
 }
@@ -714,6 +762,22 @@ interface Props {
 
 export function ScannerScreen({ navigation }: Props) {
   const cameraRef = useRef<VisionCameraRefProps>(null);
+  // Camera Controls API (Phase 3, spec §8/§9) — drives zoom/torch below and
+  // supplies live `capabilities`/`state` for the debug chip. `cameraRef`
+  // above stays the source of truth for capture/start/stop/rescan/
+  // setFocusSettings/pauseDetection/resumeDetection, none of which are part
+  // of this hook's surface.
+  const camera = useCameraControls();
+  const setVisionCameraRef = useCallback(
+    (instance: VisionCameraRefProps | null) => {
+      (cameraRef as React.MutableRefObject<VisionCameraRefProps | null>).current = instance;
+      // `camera.ref` is a real callback ref (see useCameraControls.ts); invoking
+      // it directly is how the hook observes attach/detach when composed with
+      // a second ref like this.
+      camera.ref(instance);
+    },
+    [camera.ref]
+  );
   const insets = useSafeAreaInsets();
 
   const [hasPermission, setHasPermission] = useState(false);
@@ -743,13 +807,24 @@ export function ScannerScreen({ navigation }: Props) {
     VisionCameraDetectedCodeBoundingBox[]
   >([]);
 
-  // Recognition indicators
-  const [recognition, setRecognition] = useState({
+  // Recognition indicators — kept in a ref-backed external store, NOT React
+  // state, so per-frame updates (~20-30Hz once the throttle is removed) re-render
+  // ONLY the IndicatorColumn subtree via useSyncExternalStore, not the whole
+  // ScannerScreen. Re-rendering the entire screen per frame was capping the FPS.
+  const recognitionRef = useRef<RecognitionState>({
     text: false,
     barcode: false,
     qrcode: false,
     document: false,
   });
+  const recognitionListeners = useRef(new Set<() => void>());
+  const subscribeRecognition = useCallback((cb: () => void) => {
+    recognitionListeners.current.add(cb);
+    return () => {
+      recognitionListeners.current.delete(cb);
+    };
+  }, []);
+  const getRecognition = useCallback(() => recognitionRef.current, []);
   const [sharpness, setSharpness] = useState(1);
   const lastSharpnessRef = useRef(0);
   const sharpnessThrottle = 200;
@@ -946,7 +1021,8 @@ export function ScannerScreen({ navigation }: Props) {
   // ---------------------------------------------------------------------------
   const handleRecognitionUpdate = useCallback(
     (e: VisionCameraRecognitionUpdateEvent) => {
-      setRecognition(e);
+      recognitionRef.current = e;
+      recognitionListeners.current.forEach((cb) => cb());
       tickCbFps();
     },
     [tickCbFps]
@@ -1311,10 +1387,18 @@ export function ScannerScreen({ navigation }: Props) {
   // ---------------------------------------------------------------------------
   // Zoom
   // ---------------------------------------------------------------------------
+  // Live per-facing zoom stops from getCameraCapabilities() (fetched by
+  // useCameraControls() on camera attach); falls back to ZOOM_PRESETS while
+  // capabilities haven't resolved yet or report no stops for this facing.
+  const zoomStops = useMemo(() => {
+    const stops = camera.capabilities?.zoomStops?.[cameraFacing];
+    return stops && stops.length > 0 ? stops : ZOOM_PRESETS;
+  }, [camera.capabilities, cameraFacing]);
+
   const handleZoomSelect = useCallback((z: number) => {
     setZoomLevel(z);
-    cameraRef.current?.setZoom(z);
-  }, []);
+    camera.setZoom(z);
+  }, [camera.setZoom]);
 
   // ---------------------------------------------------------------------------
   // Flash
@@ -1322,8 +1406,8 @@ export function ScannerScreen({ navigation }: Props) {
   const toggleFlash = useCallback(() => {
     const next = !flashEnabled;
     setFlashEnabled(next);
-    cameraRef.current?.toggleFlash(next);
-  }, [flashEnabled]);
+    camera.setTorch(next);
+  }, [flashEnabled, camera.setTorch]);
 
   // ---------------------------------------------------------------------------
   // Detection enabled toggle — pauses/resumes per-frame detection while the
@@ -1447,10 +1531,10 @@ export function ScannerScreen({ navigation }: Props) {
         {/* ── Camera fill ── */}
         {hasPermission ? (
           <VisionCamera
-            ref={cameraRef}
+            ref={setVisionCameraRef}
             style={StyleSheet.absoluteFill}
-            enableFlash={flashEnabled}
-            zoomLevel={zoomLevel}
+            torch={flashEnabled}
+            zoomRatio={zoomLevel}
             scanMode={effectiveScanMode}
             autoCapture={autoCapture}
             cameraFacing={cameraFacing}
@@ -1464,6 +1548,7 @@ export function ScannerScreen({ navigation }: Props) {
             onSharpnessScoreUpdate={handleSharpnessUpdate}
             onBarcodeDetected={handleBarcodeDetected}
             onBoundingBoxesUpdate={handleBoundingBoxesUpdate}
+            onCameraStateChanged={camera.onCameraStateChanged}
             detectionConfig={{
               text: true,
               barcode: true,
@@ -1541,6 +1626,20 @@ export function ScannerScreen({ navigation }: Props) {
           {/* Right: sharpness readout (OCR/Photo only — that's the only pipeline
               the native SDK computes it for) + sound icon (position absolute) */}
           <View style={styles.topRight} pointerEvents="box-none">
+            {/* Camera Controls API manual-inspection chip (spec §9) — raw
+                onCameraStateChanged/getCameraCapabilities readout via
+                useCameraControls(), for eyeballing state during on-device
+                verification (never gated on a build flag; harmless no-op
+                text if the native side hasn't wired the event yet). */}
+            {camera.state ? (
+              <View style={styles.sharpnessChip} pointerEvents="none">
+                <Text style={styles.fpsText}>
+                  {camera.state.status} z:{camera.state.zoomRatio.toFixed(1)}{' '}
+                  {camera.state.activeLensId ?? 'auto'}
+                  {camera.state.warningCode ? ` ⚠${camera.state.warningCode}` : ''}
+                </Text>
+              </View>
+            ) : null}
             {scanMode === 'ocr' || scanMode === 'photo' ? (
               <View style={styles.sharpnessChip} pointerEvents="none">
                 <Text
@@ -1575,7 +1674,14 @@ export function ScannerScreen({ navigation }: Props) {
         </View>
 
         {/* ── VERTICAL INDICATOR COLUMN (right edge, below top strip) ── */}
-        <IndicatorColumn recognition={recognition} topInset={topInset} />
+        <IndicatorColumn
+          subscribeRecognition={subscribeRecognition}
+          getRecognition={getRecognition}
+          topInset={topInset}
+          detectionEnabled={detectionEnabled}
+          onDetectionToggle={handleDetectionToggle}
+          showDetectionToggle={!isTemplateCreateMode}
+        />
 
         {/* ── OCR MODULE PILL — large, centered, above Online/On-Device ── */}
         {showOcrRow ? (
@@ -1659,21 +1765,8 @@ export function ScannerScreen({ navigation }: Props) {
           </View>
         ) : null}
 
-        {/* ── DETECTION ENABLED TOGGLE — left edge, below top strip ── */}
-        {!isTemplateCreateMode ? (
-          <View style={[styles.detectionToggleRow, { top: topInset + 44 }]} pointerEvents="box-none">
-            <View style={styles.detectionTogglePill}>
-              <Text style={styles.detectionToggleLabel}>Detection Enabled</Text>
-              <Switch
-                value={detectionEnabled}
-                onValueChange={handleDetectionToggle}
-                trackColor={{ false: theme.colors.indicatorOff, true: theme.colors.accent }}
-                thumbColor={detectionEnabled ? theme.colors.textOnAccent : '#5A5A5E'}
-                style={styles.detectionToggleSwitch}
-              />
-            </View>
-          </View>
-        ) : null}
+        {/* Detection-enabled toggle now lives in the right-edge IndicatorColumn
+            (switch-only, below the document indicator). */}
 
         {/* ── ON-DEVICE HINT ── */}
         {showOnDeviceHint ? (
@@ -1839,14 +1932,14 @@ export function ScannerScreen({ navigation }: Props) {
                 <Text style={styles.zoomValueLabel}>{zoomLevel.toFixed(1)}×</Text>
                 <ZoomSlider
                   value={zoomLevel}
-                  min={ZOOM_PRESETS[0]!}
-                  max={ZOOM_PRESETS[ZOOM_PRESETS.length - 1]!}
+                  min={camera.state?.minZoomRatio ?? zoomStops[0]!}
+                  max={camera.state?.maxZoomRatio ?? zoomStops[zoomStops.length - 1]!}
                   onValueChange={handleZoomSelect}
                 />
               </>
             ) : (
               <View style={styles.zoomPills}>
-                {ZOOM_PRESETS.map((z) => {
+                {zoomStops.map((z) => {
                   const selected = Math.abs(zoomLevel - z) < 0.05;
                   return (
                     <TouchableOpacity
@@ -1858,7 +1951,7 @@ export function ScannerScreen({ navigation }: Props) {
                       <Text
                         style={[styles.zoomPillText, selected && styles.zoomPillTextSelected]}
                       >
-                        {z === 1.0 ? '1×' : `${z}×`}
+                        {z === 1.0 ? '1×' : `${Math.floor(z * 10) / 10}×`}
                       </Text>
                     </TouchableOpacity>
                   );
@@ -1924,16 +2017,21 @@ export function ScannerScreen({ navigation }: Props) {
       <SheetPicker
         visible={showModePicker}
         title="Scan Mode"
-        options={
-          Platform.OS === 'ios'
-            ? [...SCAN_MODES, { label: 'Dimensioning', value: 'dimensioning' as VisionCameraScanMode }]
-            : SCAN_MODES
-        }
+        options={[
+          ...SCAN_MODES,
+          ...(Platform.OS === 'ios'
+            ? [{ label: 'Dimensioning', value: 'dimensioning' as VisionCameraScanMode }]
+            : []),
+          { label: 'Camera Controls QA', value: 'cameraControlsQA' as VisionCameraScanMode },
+        ]}
         current={scanMode === 'barcodesinglecapture' ? 'barcode' : scanMode}
         onSelect={(mode) => {
           if ((mode as string) === 'dimensioning') {
             setShowModePicker(false);
             navigation.navigate('DimensioningScreen');
+          } else if ((mode as string) === 'cameraControlsQA') {
+            setShowModePicker(false);
+            navigation.navigate('CameraControlsQAScreen');
           } else {
             handleModeSelect(mode);
           }
@@ -2049,16 +2147,27 @@ const INDICATOR_DEFS: { key: keyof RecognitionState; icon: string; label: string
 ];
 
 function IndicatorColumn({
-  recognition,
+  subscribeRecognition,
+  getRecognition,
   topInset,
+  detectionEnabled,
+  onDetectionToggle,
+  showDetectionToggle,
 }: {
-  recognition: RecognitionState;
+  subscribeRecognition: (cb: () => void) => () => void;
+  getRecognition: () => RecognitionState;
   topInset: number;
+  detectionEnabled: boolean;
+  onDetectionToggle: (v: boolean) => void;
+  showDetectionToggle: boolean;
 }) {
+  // Subscribes to the per-frame recognition store; only THIS subtree re-renders
+  // on each recognition tick, not the whole ScannerScreen.
+  const recognition = useSyncExternalStore(subscribeRecognition, getRecognition);
   return (
     <View
       style={[indStyles.column, { top: topInset + 48 }]}
-      pointerEvents="none"
+      pointerEvents="box-none"
     >
       {INDICATOR_DEFS.map(({ key, icon, label }) => {
         const active = recognition[key];
@@ -2081,6 +2190,17 @@ function IndicatorColumn({
           </View>
         );
       })}
+      {showDetectionToggle ? (
+        <View style={indStyles.detectionSwitchWrap} pointerEvents="auto">
+          <Switch
+            value={detectionEnabled}
+            onValueChange={onDetectionToggle}
+            trackColor={{ false: theme.colors.indicatorOff, true: theme.colors.accent }}
+            thumbColor={detectionEnabled ? theme.colors.textOnAccent : '#5A5A5E'}
+            style={indStyles.detectionSwitch}
+          />
+        </View>
+      ) : null}
     </View>
   );
 }
@@ -2115,6 +2235,14 @@ const indStyles = StyleSheet.create({
   },
   dotLabelActive: {
     color: theme.colors.indicatorOn,
+  },
+  detectionSwitchWrap: {
+    marginTop: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  detectionSwitch: {
+    transform: [{ scaleX: 0.8 }, { scaleY: 0.8 }],
   },
 });
 

--- a/ios/Fabric/VisionCameraViewComponentView.mm
+++ b/ios/Fabric/VisionCameraViewComponentView.mm
@@ -87,6 +87,14 @@ using namespace facebook::react;
         };
         ((void (*)(id, SEL, id))objc_msgSend)(_visionCameraView, onBoundingBoxesUpdateSetter, boundingBoxBlock);
       }
+
+      SEL onCameraStateChangedSetter = NSSelectorFromString(@"setOnCameraStateChanged:");
+      if ([_visionCameraView respondsToSelector:onCameraStateChangedSetter]) {
+        id cameraStateBlock = ^(NSDictionary *event) {
+          [weakSelf emitCameraStateChangedEvent:event];
+        };
+        ((void (*)(id, SEL, id))objc_msgSend)(_visionCameraView, onCameraStateChangedSetter, cameraStateBlock);
+      }
     } else {
       // Fallback to placeholder if Swift class not available
       _visionCameraView = [[UIView alloc] initWithFrame:self.bounds];
@@ -311,6 +319,42 @@ using namespace facebook::react;
     }
   }
 
+  // Camera Controls API (Phase 3)
+  if (oldViewProps.zoomRatio != newViewProps.zoomRatio) {
+    SEL setter = NSSelectorFromString(@"setZoomRatio:");
+    if ([_visionCameraView respondsToSelector:setter]) {
+      NSNumber *value = @(newViewProps.zoomRatio);
+      ((void (*)(id, SEL, id))objc_msgSend)(_visionCameraView, setter, value);
+    }
+  }
+
+  if (oldViewProps.torch != newViewProps.torch) {
+    SEL setter = NSSelectorFromString(@"setTorch:");
+    if ([_visionCameraView respondsToSelector:setter]) {
+      BOOL value = newViewProps.torch;
+      ((void (*)(id, SEL, BOOL))objc_msgSend)(_visionCameraView, setter, value);
+    }
+  }
+
+  if (oldViewProps.focusMode != newViewProps.focusMode) {
+    SEL setter = NSSelectorFromString(@"setFocusMode:");
+    if ([_visionCameraView respondsToSelector:setter]) {
+      NSString *value = [NSString stringWithUTF8String:newViewProps.focusMode.c_str()];
+      ((void (*)(id, SEL, id))objc_msgSend)(_visionCameraView, setter, value);
+    }
+  }
+
+  if (oldViewProps.pinnedLensId != newViewProps.pinnedLensId) {
+    SEL setter = NSSelectorFromString(@"setPinnedLensId:");
+    if ([_visionCameraView respondsToSelector:setter]) {
+      NSString *value = nil;
+      if (!newViewProps.pinnedLensId.empty()) {
+        value = [NSString stringWithUTF8String:newViewProps.pinnedLensId.c_str()];
+      }
+      ((void (*)(id, SEL, id))objc_msgSend)(_visionCameraView, setter, value);
+    }
+  }
+
   [super updateProps:props oldProps:oldProps];
 }
 
@@ -329,8 +373,10 @@ using namespace facebook::react;
 
   if (commandId != nil) {
     // Map command IDs to command names based on the order in supportedCommands array
-    // From VisionCameraViewNativeComponent.ts: ['capture', 'stop', 'start', 'rescan', 'toggleFlash', 'setZoom', 'setFocusSettings', 'pauseDetection', 'resumeDetection']
-    NSArray *commandNames = @[@"capture", @"stop", @"start", @"rescan", @"toggleFlash", @"setZoom", @"setFocusSettings", @"pauseDetection", @"resumeDetection"];
+    // From VisionCameraViewNativeComponent.ts: ['capture', 'stop', 'start', 'rescan', 'toggleFlash', 'setZoom', 'setFocusSettings', 'pauseDetection', 'resumeDetection', 'setTorchEnabled', 'setFocusPoint']
+    // Order is locked three-files-in-sync with the TS supportedCommands array and Android's
+    // receiveCommand `when` switch — do not reorder without updating all three.
+    NSArray *commandNames = @[@"capture", @"stop", @"start", @"rescan", @"toggleFlash", @"setZoom", @"setFocusSettings", @"pauseDetection", @"resumeDetection", @"setTorchEnabled", @"setFocusPoint"];
 
     NSInteger cmdId = [commandId integerValue];
     if (cmdId >= 0 && cmdId < commandNames.count) {
@@ -396,7 +442,13 @@ using namespace facebook::react;
   }
 }
 
-- (void)setZoom:(CGFloat)level
+// ABI FIX (on-device: every setZoom command arrived as 0.000, resetting zoom to min —
+// "slider snaps to 1x on release"): the codegen protocol declares `- (void)setZoom:(float)level`
+// (4-byte float, passed in s0). Declaring the implementation with CGFloat (8-byte double on
+// arm64, read from d0) made it read a register the caller never wrote — garbage ≈ 0.0.
+// The parameter type MUST match the generated protocol exactly; widen to CGFloat only for
+// the Swift method's NSInvocation (setZoomWithLevel: takes CGFloat).
+- (void)setZoom:(float)level
 {
   SEL selector = NSSelectorFromString(@"setZoomWithLevel:");
   if ([_visionCameraView respondsToSelector:selector]) {
@@ -404,7 +456,8 @@ using namespace facebook::react;
     NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
     [invocation setSelector:selector];
     [invocation setTarget:_visionCameraView];
-    [invocation setArgument:&level atIndex:2];
+    CGFloat widened = level;
+    [invocation setArgument:&widened atIndex:2];
     [invocation invoke];
   }
 }
@@ -414,6 +467,43 @@ using namespace facebook::react;
   SEL selector = NSSelectorFromString(@"setFocusSettingsWithJsonString:");
   if ([_visionCameraView respondsToSelector:selector]) {
     ((void (*)(id, SEL, id))objc_msgSend)(_visionCameraView, selector, settingsJson);
+  }
+}
+
+// Camera Controls API (Phase 3). NOTE: named setTorchEnabled (not setTorch) to avoid
+// an Android codegen collision — see the matching comment in
+// VisionCameraViewNativeComponent.ts. Not aliased with the `torch` prop's own
+// synthesized `setTorch:` setter, so no Obj-C selector collision either.
+- (void)setTorchEnabled:(BOOL)enabled
+{
+  SEL selector = NSSelectorFromString(@"setTorchEnabled:");
+  if ([_visionCameraView respondsToSelector:selector]) {
+    NSMethodSignature *signature = [_visionCameraView methodSignatureForSelector:selector];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    [invocation setSelector:selector];
+    [invocation setTarget:_visionCameraView];
+    [invocation setArgument:&enabled atIndex:2];
+    [invocation invoke];
+  }
+}
+
+// ABI FIX — same float-vs-CGFloat register mismatch as setZoom above: the generated
+// protocol declares `- (void)setFocusPoint:(float)x y:(float)y`, so a CGFloat-typed
+// implementation read both coordinates as garbage ≈ (0,0). Tap-to-focus was silently
+// focusing at the top-left corner on every tap.
+- (void)setFocusPoint:(float)x y:(float)y
+{
+  SEL selector = NSSelectorFromString(@"setFocusPoint::");
+  if ([_visionCameraView respondsToSelector:selector]) {
+    NSMethodSignature *signature = [_visionCameraView methodSignatureForSelector:selector];
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    [invocation setSelector:selector];
+    [invocation setTarget:_visionCameraView];
+    CGFloat widenedX = x;
+    CGFloat widenedY = y;
+    [invocation setArgument:&widenedX atIndex:2];
+    [invocation setArgument:&widenedY atIndex:3];
+    [invocation invoke];
   }
 }
 
@@ -549,6 +639,43 @@ using namespace facebook::react;
     }
 
     emitter->onBoundingBoxesUpdate(event);
+  }
+}
+
+// Camera Controls API (Phase 3). All fields are scalars (string/Float/bool) per the
+// JSON-string convention (§5.10) — no array/object payloads here, so no JSON encoding.
+- (void)emitCameraStateChangedEvent:(NSDictionary *)eventData
+{
+  if (_eventEmitter != nullptr) {
+    auto emitter = std::static_pointer_cast<VisionCameraViewEventEmitter const>(_eventEmitter);
+
+    VisionCameraViewEventEmitter::OnCameraStateChanged event = {};
+    event.status = std::string([[eventData objectForKey:@"status"] UTF8String] ?: "");
+    event.facing = std::string([[eventData objectForKey:@"facing"] UTF8String] ?: "");
+    event.zoomRatio = [[eventData objectForKey:@"zoomRatio"] floatValue];
+    event.minZoomRatio = [[eventData objectForKey:@"minZoomRatio"] floatValue];
+    event.maxZoomRatio = [[eventData objectForKey:@"maxZoomRatio"] floatValue];
+    event.torchEnabled = [[eventData objectForKey:@"torchEnabled"] boolValue];
+    event.focusMode = std::string([[eventData objectForKey:@"focusMode"] UTF8String] ?: "");
+    event.isPreviewActive = [[eventData objectForKey:@"isPreviewActive"] boolValue];
+
+    if ([eventData objectForKey:@"activeLensId"]) {
+      event.activeLensId = std::string([[eventData objectForKey:@"activeLensId"] UTF8String]);
+    }
+    if ([eventData objectForKey:@"errorCode"]) {
+      event.errorCode = std::string([[eventData objectForKey:@"errorCode"] UTF8String]);
+    }
+    if ([eventData objectForKey:@"errorMessage"]) {
+      event.errorMessage = std::string([[eventData objectForKey:@"errorMessage"] UTF8String]);
+    }
+    if ([eventData objectForKey:@"warningCode"]) {
+      event.warningCode = std::string([[eventData objectForKey:@"warningCode"] UTF8String]);
+    }
+    if ([eventData objectForKey:@"warningMessage"]) {
+      event.warningMessage = std::string([[eventData objectForKey:@"warningMessage"] UTF8String]);
+    }
+
+    emitter->onCameraStateChanged(event);
   }
 }
 

--- a/ios/RNVisionCameraView.swift
+++ b/ios/RNVisionCameraView.swift
@@ -1,6 +1,5 @@
 import UIKit
 import VisionSDK
-import AVFoundation
 
 // MARK: - FocusSettings Helper
 @available(iOS 13.0, *)
@@ -58,7 +57,9 @@ class RNVisionCameraView: UIView {
   @objc var onSharpnessScoreUpdate: RCTDirectEventBlock?
   @objc var onBarcodeDetected: RCTDirectEventBlock?
   @objc var onBoundingBoxesUpdate: RCTDirectEventBlock?
-  
+  // Camera Controls API (Phase 3) — throttled full-state event (§8).
+  @objc var onCameraStateChanged: RCTDirectEventBlock?
+
   // MARK: - Properties
   @objc var enableFlash: Bool = false {
     didSet {
@@ -138,6 +139,74 @@ class RNVisionCameraView: UIView {
     didSet {
       applyCodeBoundingBoxSettings()
     }
+  }
+
+  // MARK: - Camera Controls API (Phase 3)
+  // Canonical props; zoomLevel/enableFlash above stay as deprecated aliases feeding
+  // the same native path. C2 fix: once a canonical prop is set here it wins over its
+  // legacy alias for good (isTorchSet/isZoomRatioSet below) — see VisionCamera.tsx
+  // (Task 18) for the JS-side precedence this mirrors.
+
+  @objc var zoomRatio: NSNumber = 1.0 {
+    didSet {
+      isZoomRatioSet = true // C2: canonical prop now wins over zoomLevel, permanently
+      updateZoom() // zoomLevel and zoomRatio converge on the same setter
+    }
+  }
+
+  @objc var torch: Bool = false {
+    didSet {
+      isTorchSet = true // C2: canonical prop now wins over enableFlash, permanently
+      updateFlash() // torch and enableFlash converge on the same setter
+    }
+  }
+
+  // C2 fix: once a canonical prop (`torch`/`zoomRatio`) has been explicitly set by
+  // JS, it wins over the legacy alias (`enableFlash`/`zoomLevel`) for the rest of
+  // this view's lifetime — mirrors Android's ControlPropsState "new prop wins over
+  // legacy" contract. Without this, `updateFlash`/`updateZoom` read the legacy prop
+  // unconditionally, so e.g. setting only `torch=true` got silently overwritten by
+  // `enableFlash`'s default (false) on the very next reassert.
+  private var isTorchSet: Bool = false
+  private var isZoomRatioSet: Bool = false
+
+  private var resolvedTorch: Bool {
+    isTorchSet ? torch : enableFlash
+  }
+
+  private var resolvedZoomRatio: Float {
+    isZoomRatioSet ? zoomRatio.floatValue : zoomLevel.floatValue
+  }
+
+  @objc var focusMode: NSString? {
+    didSet {
+      updateFocusMode()
+    }
+  }
+
+  @objc var pinnedLensId: NSString? {
+    didSet {
+      reassertControlProps()
+    }
+  }
+
+  /// One-shot flag: set when `applyLensSelection()` falls back to `.automatic`
+  /// because `pinnedLensId` named an unknown/unpinnable lens. Consumed (and cleared)
+  /// by the next emitted `onCameraStateChanged` event as `warningCode: "lens-unavailable"`.
+  private var pendingLensUnavailableWarning: Bool = false
+
+  /// Last (facing, pinnedLensId) pair actually applied via `applyLensSelection()`.
+  /// `reassertControlProps()` skips the lens re-apply when this hasn't changed —
+  /// Group B persists the lens via `makeCameraConfiguration()` now, so re-resolving
+  /// it on every RUNNING transition is a needless structural reconcile. `nil` means
+  /// "never applied on the current cameraView" and always forces one application;
+  /// reset in `setupCamera()` so a freshly created cameraView always gets a lens.
+  private var lastAppliedLensKey: String?
+
+  private func currentLensKey() -> String {
+    let facing = (cameraFacing as String?)?.lowercased() == "front" ? "front" : "back"
+    let lensId = (pinnedLensId as String?) ?? ""
+    return "\(facing)|\(lensId)"
   }
 
   /// Builds a single coherent FocusSettings from the full current prop state:
@@ -220,6 +289,17 @@ class RNVisionCameraView: UIView {
   private var isSetupComplete = false
   private var shouldAutoStart = true
 
+  // MARK: - Camera Controls API (Phase 3) — state-event throttling
+  private var lastCameraStateEmitTime: TimeInterval = 0
+  private var lastCameraStateStatus: String?
+  private let cameraStateThrottleSeconds: TimeInterval = 0.1 // 10 Hz, matches Android's CAMERA_STATE_THROTTLE_MS
+  // Trailing-edge guarantee: the throttle above is a drop-throttle, so a burst of
+  // state changes ending mid-window would otherwise leave JS on stale data. This
+  // schedules a single deferred emit of the LATEST state at the window boundary;
+  // a newer skipped emit cancels/replaces it, so exactly one trailing emit lands
+  // with the freshest state.
+  private var trailingCameraStateWorkItem: DispatchWorkItem?
+
   // MARK: - Initialization
   override init(frame: CGRect) {
     super.init(frame: frame)
@@ -249,8 +329,7 @@ class RNVisionCameraView: UIView {
         updateCaptureMode()
         updateDetectionConfig()
         updateFrameSkip()
-        updateFlash()
-        updateZoom()
+        reassertControlProps() // zoomRatio/torch/focusMode/pinnedLensId
         applyCodeBoundingBoxSettings()
 
         // Start camera immediately - no need to delay
@@ -301,7 +380,7 @@ class RNVisionCameraView: UIView {
 
     // Re-apply props that may have been set before this recreation
     applyCodeBoundingBoxSettings()
-    updateZoom()
+    reassertControlProps() // zoomRatio/torch/focusMode/pinnedLensId
 
     // Ensure frame is correct
     cameraView?.frame = self.bounds
@@ -318,6 +397,11 @@ class RNVisionCameraView: UIView {
 
     self.addSubview(cameraView)
 
+    // Fresh cameraView never had a lens applied — force one on the next
+    // reassertControlProps(), regardless of whether (facing, pinnedLensId) happens
+    // to match what was applied to the previous (now-discarded) cameraView.
+    lastAppliedLensKey = nil
+
     // Configure with minimal settings
     cameraView.configure(
       delegate: self,
@@ -329,6 +413,10 @@ class RNVisionCameraView: UIView {
 
     // Disable default SDK bounding boxes
     updateScanArea()
+
+    // Replay-on-attach: emit the current camera state once immediately so
+    // onCameraStateChanged listeners are never stale-undefined (spec §8).
+    emitCameraState(cameraView.currentCameraState, bypassThrottle: true)
 
     // Stop initially, will auto-start after layout
     cameraView.stopRunning()
@@ -460,7 +548,8 @@ class RNVisionCameraView: UIView {
     // Update actual state based on what operation completed
     if actualCameraState == .starting {
       actualCameraState = success ? .running : .stopped
-      if success { updateZoom() }
+      // Re-assert declarative control props on every RUNNING transition (spec §8).
+      if success { reassertControlProps() }
     } else if actualCameraState == .stopping {
       actualCameraState = .stopped
     }
@@ -483,6 +572,19 @@ class RNVisionCameraView: UIView {
   /// isScanning=false until rescan resets it). On iOS this just delegates to
   /// the existing internal cameraView.rescan() — safe to call after each capture.
   @objc func rescan() {
+    // Android parity: rescan() on a stopped/unbound camera must rebuild it, not
+    // silently no-op. CodeScannerView.rescan() only issues a fresh bind when the
+    // underlying VSDKCameraSession is already .idle/.error (see its own doc comment) —
+    // while this view's own actualCameraState tracker is anything but running/starting,
+    // route through start() instead, so targetState/actualCameraState/
+    // reassertControlProps stay in sync with the camera actually coming back up.
+    guard actualCameraState == .running || actualCameraState == .starting else {
+      NSLog("[RNVisionCameraView] rescan: camera not running (state=%@) — routing to start()", String(describing: actualCameraState))
+      start()
+      return
+    }
+    // Running: CodeScannerView.rescan() re-arms detection (clears detected codes/overlays,
+    // shouldReturnDetectedCodes=true) — no visible preview change by design.
     cameraView?.rescan()
   }
 
@@ -500,13 +602,40 @@ class RNVisionCameraView: UIView {
   }
 
   @objc func toggleFlash(enabled: Bool) {
-    self.enableFlash = enabled
-    updateFlash()
+    // Docs review C1 — identical bug class to setZoom below: this wrote only the legacy
+    // `enableFlash` alias, but `resolvedTorch` permanently prefers the canonical `torch`
+    // prop once `isTorchSet` flips true — which happens on EVERY mount (the codegen spec
+    // declares `torch` with WithDefault<boolean, false>, so Fabric dispatches the default
+    // at view creation). updateFlash() then re-applied torch=false, actively forcing the
+    // torch OFF — toggleFlash was not just dead, it was inverted. Route through the
+    // canonical prop's didSet, mirroring setTorchEnabled below.
+    torch = enabled
   }
   
   @objc func setZoom(level: CGFloat) {
-    self.zoomLevel = NSNumber(value: Float(level))
-    updateZoom()
+    // Route through the canonical `zoomRatio` prop's didSet, mirroring setTorchEnabled
+    // below — otherwise this command is a permanent no-op once `isZoomRatioSet` has
+    // flipped true, which happens on EVERY view mount: the codegen spec declares
+    // `zoomRatio` with `WithDefault<Double, 1.0>`, so Fabric dispatches its default
+    // value at view creation regardless of whether JS ever explicitly binds the prop.
+    // Previously this wrote only the legacy `zoomLevel` alias, which `resolvedZoomRatio`
+    // never reads once isZoomRatioSet is true — the imperative setZoom() command (the
+    // zoom slider's drag handler) was silently dropped from the very first frame.
+    zoomRatio = NSNumber(value: Float(level))
+  }
+
+  // Camera Controls API (Phase 3) — commands. setFocusSettings below stays SEPARATE/
+  // unaliased: it configures overlay styling (focus-image display, bbox colors), a
+  // different concern from these one-shot autofocus/torch runtime controls.
+  @objc func setTorchEnabled(_ enabled: Bool) {
+    // Route through the `torch` prop's didSet so this command updates the same
+    // resolved-value store as C2 (isTorchSet + updateFlash) — otherwise the value
+    // is lost on the next reassertControlProps() (facing change / RUNNING transition).
+    torch = enabled
+  }
+
+  @objc func setFocusPoint(_ x: CGFloat, _ y: CGFloat) {
+    cameraView?.setFocusPoint(CGPoint(x: x, y: y))
   }
 
   @objc func setFocusSettings(jsonString: NSString) {
@@ -628,57 +757,119 @@ class RNVisionCameraView: UIView {
     return nil
   }
   
+  // Camera Controls API (Phase 3): both delegate to CodeScannerView, which already
+  // centralizes the switch-over-factor zoom conversion and torch control internally
+  // (core-routed through cameraSession.controller) — no raw AVCaptureDevice access
+  // needed here anymore. Deleted: the videoDevice lockForConfiguration()/torchMode/
+  // virtualDeviceSwitchOverVideoZoomFactors hack this used to hand-roll.
   private func updateFlash() {
     guard let cameraView = cameraView else { return }
-
-    do {
-      let videoDevice = try cameraView.videoDevice
-
-      DispatchQueue.main.async {
-        if videoDevice.isTorchAvailable {
-          do {
-            try videoDevice.lockForConfiguration()
-            if self.enableFlash {
-              try videoDevice.setTorchModeOn(level: 1.0)
-            } else {
-              videoDevice.torchMode = .off
-            }
-            videoDevice.unlockForConfiguration()
-          } catch {
-            print("[RNVisionCameraView] Error setting torch: \(error)")
-          }
-        }
-      }
-    } catch {
-      print("[RNVisionCameraView] Error getting video device: \(error)")
-    }
+    cameraView.setFlashTurnedOn(resolvedTorch)
   }
-  
+
   private func updateZoom() {
-    guard let videoDevice = try? cameraView?.videoDevice else { return }
-
-    var zoomValue = CGFloat(zoomLevel.floatValue)
-
-    // Normalize so zoomLevel 1.0 = primary (wide) camera on all devices.
-    // On virtual devices that start at ultra-wide, the first switchover factor marks where wide starts.
-    if videoDevice.constituentDevices.first?.deviceType == .builtInUltraWideCamera,
-       let wideZoom = videoDevice.virtualDeviceSwitchOverVideoZoomFactors.first {
-      zoomValue *= CGFloat(truncating: wideZoom)
-    }
-
-    DispatchQueue.main.async {
-      do {
-        try videoDevice.lockForConfiguration()
-        defer { videoDevice.unlockForConfiguration() }
-        zoomValue = min(max(zoomValue, videoDevice.minAvailableVideoZoomFactor),
-                        videoDevice.maxAvailableVideoZoomFactor)
-        videoDevice.videoZoomFactor = zoomValue
-      } catch {
-        print("[RNVisionCameraView] Error setting zoom: \(error)")
-      }
-    }
+    guard let cameraView = cameraView else { return }
+    cameraView.setZoomRatio(resolvedZoomRatio)
   }
-  
+
+  private func updateFocusMode() {
+    guard let cameraView = cameraView, let mode = focusMode as String? else { return }
+    let vsdkMode: VSDKFocusMode
+    switch mode.lowercased() {
+    case "single": vsdkMode = .single
+    case "locked": vsdkMode = .locked
+    default: vsdkMode = .continuous
+    }
+    cameraView.setFocusMode(vsdkMode)
+  }
+
+  /// Resolves `pinnedLensId` (a JS-supplied lens id string) against the lenses
+  /// available for EITHER facing and pins it. Unknown/unpinnable ids NEVER throw —
+  /// they fall back to `.automatic` and set a one-shot warning flag that the next
+  /// `onCameraStateChanged` event surfaces (spec §8).
+  ///
+  /// Bug fix (parity with Android QA Group A #2) — a pinnable lens id only ever
+  /// appears under its OWN facing's list (a front lens is never returned by
+  /// `lenses(for: .back)` and vice versa), so gating this lookup to whatever facing
+  /// the `cameraFacing` prop currently holds meant pinning a lens from the OTHER
+  /// facing silently fell back to Auto with a warning — reproduced on-device:
+  /// pinning id=5 (front) while `cameraFacing` is still "back" logged "pinnedLensId
+  /// '5' unknown or unpinnable for facing=back". Search both facings so the pin
+  /// resolves regardless of prop-set order, then bring the camera's facing in line
+  /// with whichever facing the resolved lens actually belongs to.
+  private func applyLensSelection() {
+    guard let cameraView = cameraView else { return }
+    // `CodeScannerView.setLensSelection` builds its `VSDKCameraConfiguration` from
+    // `cameraSettings.cameraPosition` (the facing last applied via
+    // `setCameraSettingsTo`), NOT from this view's `cameraFacing` prop — so facing and
+    // the resolved lens must agree before we hand it off, in EVERY branch below,
+    // otherwise the SDK is asked to select a lens under a facing it doesn't belong to.
+    let currentFacing: VSDKLensFacing = (cameraFacing as String?)?.lowercased() == "front" ? .front : .back
+
+    guard let lensId = pinnedLensId as String?, !lensId.isEmpty else {
+      // Bug fix (parity with Android QA Group A #3) — Auto/unpin must bring facing back
+      // in line with the `cameraFacing` prop. A prior cross-facing pin (below) only ever
+      // touches CodeScannerView's internal cameraSettings.cameraPosition directly, out of
+      // band from this prop; nothing else ever reset it back. Without this, unpinning
+      // after a FRONT lens pin called setLensSelection(.automatic) while the SDK's
+      // internal facing was still front — Auto stayed stuck on the front camera instead
+      // of returning to back. syncFacing(to:) is a no-op at the SDK layer when facing
+      // already matches, so this is safe to call unconditionally.
+      syncFacing(to: currentFacing, on: cameraView)
+      cameraView.setLensSelection(.automatic)
+      return
+    }
+    let capabilities = VSDKCameraCapabilities.snapshot()
+    let lenses = capabilities.lenses(for: .back) + capabilities.lenses(for: .front)
+    guard let lens = lenses.first(where: { $0.id == lensId && $0.isPinnable }),
+          let selection = try? VSDKLensSelection.pin(lens) else {
+      print("[RNVisionCameraView] pinnedLensId '\(lensId)' unknown or unpinnable — falling back to Auto")
+      syncFacing(to: currentFacing, on: cameraView)
+      cameraView.setLensSelection(.automatic)
+      pendingLensUnavailableWarning = true
+      return
+    }
+    // Bug fix (on-device: "pin front, then pin back — never returns to back"): the old
+    // `if lens.facing != currentFacing` gate compared against the cameraFacing PROP, but a
+    // prior cross-facing pin changed CodeScannerView's INTERNAL cameraSettings.cameraPosition
+    // out of band from that prop. Pinning a back lens while prop=back but internal=front
+    // skipped the sync, so setLensSelection built its configuration under FRONT facing and
+    // the back pin never took. syncFacing is a no-op at the SDK layer when facing already
+    // matches (see the Auto branch above), so call it unconditionally with the RESOLVED
+    // lens's facing — the only value that's correct in every ordering.
+    syncFacing(to: lens.facing, on: cameraView)
+    cameraView.setLensSelection(selection)
+  }
+
+  /// Pushes `facing` into CodeScannerView's own `cameraSettings.cameraPosition` — the
+  /// only state `setLensSelection`/`applyLensSelection` actually key off of. Shared by
+  /// every `applyLensSelection()` branch (pinned cross-facing switch, Auto/unpin
+  /// reconciliation, and unknown-lens fallback) so all three agree on one code path.
+  private func syncFacing(to facing: VSDKLensFacing, on cameraView: CodeScannerView) {
+    let cameraSettings = VisionSDK.CodeScannerView.CameraSettings()
+    cameraSettings.cameraPosition = facing == .front ? .front : .back
+    cameraSettings.nthFrameToProcess = frameSkip?.int64Value ?? 10
+    cameraView.setCameraSettingsTo(cameraSettings)
+  }
+
+  /// Re-asserts the current declarative camera-control prop values (pinnedLensId/
+  /// zoomRatio/torch/focusMode) against the native view. A facing or lens change
+  /// resets some of these to SDK defaults (spec §5.4); calling this after such a
+  /// change, and after every transition into `.running`, makes sure the declared
+  /// prop values always converge (spec §8).
+  private func reassertControlProps() {
+    guard cameraView != nil else { return }
+    let lensKey = currentLensKey()
+    if lensKey != lastAppliedLensKey {
+      applyLensSelection()
+      lastAppliedLensKey = lensKey
+    }
+    updateZoom()
+    updateFlash()
+    updateFocusMode()
+  }
+
+
   private func updateCaptureMode() {
     guard let cameraView = cameraView else { return }
 
@@ -799,8 +990,25 @@ class RNVisionCameraView: UIView {
   }
 
   /// Updates camera position dynamically when cameraFacing prop changes.
-  /// This method handles camera position changes after the camera has already started.
-  /// Note: Switching camera position requires stopping and restarting the camera session.
+  ///
+  /// Bug fix (parity with Android QA Group A #2): this used to manually stopRunning()
+  /// then setCameraSettingsTo() then startRunning() after a fixed 0.15s delay — a
+  /// leftover from before CodeScannerView grew its own live in-place facing switch
+  /// (cameraSession.update(with:), spec §11/Task 11's freeze-bridge-masked swapInput).
+  /// That manual stop landed BEFORE setCameraSettingsTo, which flips the underlying
+  /// VSDKCameraSession to .idle; setCameraSettingsTo's own cameraSession.update(with:)
+  /// call is then a same-tick no-op merge-only against an .idle session (see
+  /// SessionReconciler.update(with:)'s `.idle` case) — beginCameraSwitchBridge() still
+  /// fired regardless, freezing a preview that had already gone dark. The subsequent
+  /// facing switch back only ever "worked" by accident, via the delayed startRunning()
+  /// picking up the coalesced pendingConfiguration — a race, not a guarantee, which is
+  /// exactly why Front→Back reproduced as stuck while Back→Front didn't.
+  ///
+  /// Just delegating straight to setCameraSettingsTo (mirroring applyLensSelection's
+  /// facing-switch branch, which never did any manual stop/restart) lets
+  /// CodeScannerView's own live switch run as designed: a same-session in-place input
+  /// swap while RUNNING, or a plain pendingConfiguration merge while idle/starting —
+  /// either way, no lost facing changes.
   private func updateCameraPosition() {
     guard let cameraView = cameraView else { return }
     guard !isDeallocating else { return }
@@ -813,38 +1021,28 @@ class RNVisionCameraView: UIView {
       position = .back
     }
 
-    // IMPORTANT: Camera position change requires stopping and restarting the camera
-    // AVFoundation operations must be on main thread to avoid AutoLayout issues
-    if actualCameraState == .running || actualCameraState == .starting {
-      // Stop camera on main thread
-      DispatchQueue.main.async { [weak self] in
-        guard let self = self, let cameraView = self.cameraView else { return }
+    let cameraSettings = VisionSDK.CodeScannerView.CameraSettings()
+    cameraSettings.cameraPosition = position
+    cameraSettings.nthFrameToProcess = frameSkip?.int64Value ?? 10
+    cameraView.setCameraSettingsTo(cameraSettings)
 
-        self.isTransitioning = true
-        self.actualCameraState = .stopping
-
-        cameraView.stopRunning()
-        self.actualCameraState = .stopped
-
-        // Apply new camera settings on main thread
-        let cameraSettings = VisionSDK.CodeScannerView.CameraSettings()
-        cameraSettings.cameraPosition = position
-        cameraSettings.nthFrameToProcess = self.frameSkip?.int64Value ?? 10
-        cameraView.setCameraSettingsTo(cameraSettings)
-
-        // Small delay to let camera settle
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
-          guard let self = self, let cameraView = self.cameraView else { return }
-
-          // Restart camera on main thread
-          self.actualCameraState = .starting
-          cameraView.startRunning()
-
-          self.actualCameraState = .running
-          self.targetState = .running
-          self.isTransitioning = false
-        }
-      }
+    // Facing changed — the active lens (and its zoom/torch/focus capabilities) reset
+    // for the new facing (spec §5.4/§8); re-assert declarative control props once the
+    // in-place switch has had time to settle. CodeScannerView exposes no completion
+    // callback for this (didChangeCameraState fires on every intermediate transition
+    // too, and reasserting from inside it would re-trigger itself via applyZoom/
+    // TorchIfRunning's own state emits) — a short settle delay mirrors the pattern
+    // already used elsewhere in this file (e.g. updateScanArea's post-start delay).
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+      self?.reassertControlProps()
+    }
+    // Docs review H1 — the swap is async on the session queue with no completion callback;
+    // if it lands AFTER the 0.3s reassert, its runtimeSettings.resetToDefaults() erases the
+    // torch/zoom the reassert just wrote and nothing re-fires (status stays .running through
+    // an in-place swap). A second, idempotent reassert past any realistic swap duration
+    // closes that window. ponytail: two timers, state-driven reassert if this ever flakes.
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { [weak self] in
+      self?.reassertControlProps()
     }
   }
   
@@ -1026,5 +1224,108 @@ extension RNVisionCameraView: CodeScannerViewDelegate {
       sendError(message: "Failed to save image: \(error.localizedDescription)")
       cameraView?.rescan()
     }
+  }
+
+  // MARK: - Camera Controls API (Phase 3) — state delegate → throttled event
+
+  func codeScannerView(_ scannerView: CodeScannerView, didChangeCameraState state: VSDKCameraState) {
+    // Guards against a state callback landing mid-teardown (deinit sets this first).
+    guard !isDeallocating else { return }
+    emitCameraState(state, bypassThrottle: false)
+  }
+
+  private func cameraStatusString(_ status: VSDKCameraStatus) -> String {
+    switch status {
+    case .idle: return "idle"
+    case .starting: return "starting"
+    case .running: return "running"
+    case .interrupted: return "interrupted"
+    case .error: return "error"
+    @unknown default: return "idle"
+    }
+  }
+
+  private func cameraErrorCodeString(_ error: NSError) -> String {
+    switch VSDKCameraErrorCode(rawValue: error.code) {
+    case .permissionDenied: return "permission-denied"
+    case .lensUnavailable: return "lens-unavailable"
+    case .configurationFailed: return "configuration-failed"
+    default: return "configuration-failed"
+    }
+  }
+
+  /// Builds and emits the `onCameraStateChanged` payload. Throttled to ≤10Hz,
+  /// trailing-edge-guaranteed; status/errorCode/warningCode transitions bypass
+  /// the throttle entirely (spec §8). Payload keys must match Android's emitter
+  /// and the locked `CameraStateChangedEvent` codegen shape exactly.
+  private func emitCameraState(_ state: VSDKCameraState, bypassThrottle: Bool) {
+    let statusString = cameraStatusString(state.status)
+    let statusChanged = lastCameraStateStatus != statusString
+    let now = Date().timeIntervalSince1970
+    let hasError = state.error != nil
+    let hasWarning = state.warning != nil || pendingLensUnavailableWarning
+    let shouldEmit = bypassThrottle || statusChanged || hasError || hasWarning ||
+        (now - lastCameraStateEmitTime) >= cameraStateThrottleSeconds
+
+    guard shouldEmit else {
+      scheduleTrailingCameraStateEmit(state)
+      return
+    }
+
+    // This emit already carries the latest state — any pending trailing emit is stale.
+    trailingCameraStateWorkItem?.cancel()
+    trailingCameraStateWorkItem = nil
+    performCameraStateEmit(state, statusString: statusString)
+  }
+
+  /// Schedules a single deferred emit of `state` at the throttle window boundary
+  /// (trailing edge). Cancels/replaces any previously scheduled trailing emit, so
+  /// only the freshest state from a burst ever lands once the window elapses.
+  private func scheduleTrailingCameraStateEmit(_ state: VSDKCameraState) {
+    trailingCameraStateWorkItem?.cancel()
+    let elapsed = Date().timeIntervalSince1970 - lastCameraStateEmitTime
+    let remaining = max(0, cameraStateThrottleSeconds - elapsed)
+    let workItem = DispatchWorkItem { [weak self] in
+      guard let self = self, !self.isDeallocating else { return }
+      self.trailingCameraStateWorkItem = nil
+      self.performCameraStateEmit(state, statusString: self.cameraStatusString(state.status))
+    }
+    trailingCameraStateWorkItem = workItem
+    DispatchQueue.main.asyncAfter(deadline: .now() + remaining, execute: workItem)
+  }
+
+  private func performCameraStateEmit(_ state: VSDKCameraState, statusString: String) {
+    lastCameraStateEmitTime = Date().timeIntervalSince1970
+    lastCameraStateStatus = statusString
+
+    var payload: [String: Any] = [
+      "status": statusString,
+      "facing": state.facing == .front ? "front" : "back",
+      "zoomRatio": state.zoomRatio,
+      "minZoomRatio": state.minZoomRatio,
+      "maxZoomRatio": state.maxZoomRatio,
+      "torchEnabled": state.isTorchEnabled,
+      "isPreviewActive": state.isPreviewActive,
+    ]
+    switch state.focusMode {
+    case .single: payload["focusMode"] = "single"
+    case .locked: payload["focusMode"] = "locked"
+    default: payload["focusMode"] = "continuous"
+    }
+    if let lens = state.activeLens { payload["activeLensId"] = lens.id }
+    if let error = state.error {
+      payload["errorCode"] = cameraErrorCodeString(error)
+      payload["errorMessage"] = error.localizedDescription
+    }
+    if let warning = state.warning {
+      payload["warningCode"] = cameraErrorCodeString(warning)
+      payload["warningMessage"] = warning.localizedDescription
+    } else if pendingLensUnavailableWarning {
+      payload["warningCode"] = "lens-unavailable"
+      // Matches Android's cameraStateToMap() warningMessage string exactly.
+      payload["warningMessage"] = "pinnedLensId unavailable — falling back to Auto"
+      pendingLensUnavailableWarning = false // one-shot; consumed
+    }
+    onCameraStateChanged?(payload)
   }
 }

--- a/ios/VisionSdkModule.swift
+++ b/ios/VisionSdkModule.swift
@@ -967,4 +967,76 @@ class VisionSdkModule: RCTEventEmitter {
     }
   }
 
+  // Camera Controls API (Phase 3, Group F) — "facing" mapping mirrors
+  // RNVisionCameraView.performCameraStateEmit's `state.facing == .front ? "front" : "back"`
+  // exactly. "kind" mapping mirrors VSDKLensKind's own Swift case names (already camelCase),
+  // matching the JS `Lens.kind` union.
+  private func lensKindString(_ kind: VSDKLensKind) -> String {
+    switch kind {
+    case .ultraWide: return "ultraWide"
+    case .wide: return "wide"
+    case .telephoto: return "telephoto"
+    default: return "unknown"
+    }
+  }
+
+  /// Snapshots the device's current camera capabilities (lenses, zoom stops,
+  /// torch/focus support) for both facings, serialized to the same JSON shape
+  /// produced by the Android TurboModule implementation.
+  @objc func getCameraCapabilities(
+    _ resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    let capabilities = VSDKCameraCapabilities.snapshot()
+    let facings: [(VSDKLensFacing, String)] = [(.back, "back"), (.front, "front")]
+    var lensesArray: [[String: Any]] = []
+    var zoomStops: [String: [NSNumber]] = [:]
+    var hasTorch: [String: Bool] = [:]
+    var supportsFocusPoint: [String: Bool] = [:]
+    // Crash fix (iPhone 14 Pro, on-mount SIGABRT): NSJSONSerialization aborts the whole
+    // process on a non-finite number (inf/NaN) anywhere in the payload — a zoom division
+    // in the multi-lens capability math produced one. Sanitize EVERY numeric at this
+    // boundary (a capabilities query must never crash the app) and log the offender so
+    // the SDK-level source can be root-caused.
+    func finite(_ value: Float, _ field: String, fallback: Float) -> Float {
+      guard value.isFinite else {
+        NSLog("[VisionSdkModule] getCameraCapabilities: NON-FINITE %@ = %f — replacing with %.2f", field, Double(value), Double(fallback))
+        return fallback
+      }
+      return value
+    }
+    for (facing, name) in facings {
+      for lens in capabilities.lenses(for: facing) {
+        lensesArray.append([
+          "id": lens.id,
+          "kind": lensKindString(lens.kind),
+          "facing": name,
+          "minZoomRatio": finite(lens.minZoomRatio, "lens[\(lens.id)].minZoomRatio", fallback: 1.0),
+          "maxZoomRatio": finite(lens.maxZoomRatio, "lens[\(lens.id)].maxZoomRatio", fallback: 1.0),
+          "zoomSwitchPoints": lens.zoomSwitchPoints.map { finite($0.floatValue, "lens[\(lens.id)].zoomSwitchPoints", fallback: 1.0) },
+          "hasFlash": lens.hasFlash,
+          "isLogical": lens.isLogical,
+          "isPinnable": lens.isPinnable,
+        ])
+      }
+      zoomStops[name] = capabilities.zoomStops(for: facing).map {
+        NSNumber(value: finite($0.floatValue, "zoomStops[\(name)]", fallback: 1.0))
+      }
+      hasTorch[name] = capabilities.hasTorch(for: facing)
+      supportsFocusPoint[name] = capabilities.supportsFocusPoint(for: facing)
+    }
+    let result: [String: Any] = [
+      "lenses": lensesArray,
+      "zoomStops": zoomStops,
+      "hasTorch": hasTorch,
+      "supportsFocusPoint": supportsFocusPoint,
+    ]
+    do {
+      let data = try JSONSerialization.data(withJSONObject: result)
+      resolver(String(data: data, encoding: .utf8))
+    } catch {
+      rejecter("CAPABILITIES_ERROR", error.localizedDescription, error)
+    }
+  }
+
 }

--- a/ios/VisionSdkModuleTurboModule.mm
+++ b/ios/VisionSdkModuleTurboModule.mm
@@ -680,6 +680,25 @@ RCT_EXPORT_METHOD(predictWithModule:(NSString *)moduleJson
   }
 }
 
+RCT_EXPORT_METHOD(getCameraCapabilities:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+  NSLog(@"[VisionSDK TurboModule] getCameraCapabilities called");
+  id swiftModule = [self getSwiftModule];
+  if (swiftModule) {
+    SEL selector = NSSelectorFromString(@"getCameraCapabilities:rejecter:");
+    if ([swiftModule respondsToSelector:selector]) {
+      ((void (*)(id, SEL, RCTPromiseResolveBlock, RCTPromiseRejectBlock))objc_msgSend)(
+        swiftModule, selector, resolve, reject
+      );
+    } else {
+      reject(@"METHOD_NOT_FOUND", @"getCameraCapabilities method not found", nil);
+    }
+  } else {
+    reject(@"MODULE_NOT_FOUND", @"VisionSdkModule Swift class not found", nil);
+  }
+}
+
 // Required for event emitters
 RCT_EXPORT_METHOD(addListener:(NSString *)eventName)
 {

--- a/package.json
+++ b/package.json
@@ -146,7 +146,8 @@
     "preset": "react-native",
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules",
-      "<rootDir>/lib/"
+      "<rootDir>/lib/",
+      "<rootDir>/.worktrees/"
     ]
   },
   "commitlint": {

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -45,9 +45,9 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
   # Core scanner + OCR
-  s.dependency "VisionSDK", "= 2.3.14"
+  s.dependency "VisionSDK", "= 2.4.0"
   # 3-D box measurement — brings MVDimensioningCore.xcframework, ARKit, RealityKit, PostHog
-  s.dependency "VisionSDK/Dimensioning", "= 2.3.14"
+  s.dependency "VisionSDK/Dimensioning", "= 2.4.0"
 
   # New Architecture dependencies
   install_modules_dependencies(s)

--- a/src/VisionCamera.tsx
+++ b/src/VisionCamera.tsx
@@ -13,6 +13,7 @@ import {
   VisionCameraErrorResult,
   VisionCameraRecognitionUpdateEvent,
   VisionCameraSharpnessScoreEvent,
+  VisionCameraStateEvent,
   FocusSettings,
 } from './VisionCameraTypes';
 
@@ -26,6 +27,38 @@ function parseNativeEvent<T>(event: any): T {
   return event;
 }
 
+// iOS's Fabric typed emitter delivers absent optional strings as '""'; Android
+// sends `undefined`. Normalize once here so JS consumers see identical shapes
+// cross-platform.
+const CAMERA_STATE_OPTIONAL_STRING_KEYS = [
+  'errorCode',
+  'errorMessage',
+  'warningCode',
+  'warningMessage',
+  'activeLensId',
+] as const;
+
+function normalizeCameraStateEvent(event: VisionCameraStateEvent): VisionCameraStateEvent {
+  const normalized: any = { ...event };
+  for (const key of CAMERA_STATE_OPTIONAL_STRING_KEYS) {
+    if (normalized[key] === '') {
+      normalized[key] = undefined;
+    }
+  }
+  return normalized;
+}
+
+// Module-level "warn once" set for dev-mode prop-collision warnings — this
+// repo has no existing precedent for a one-shot dev warning helper, so this
+// introduces the minimal one.
+const warnedOnceKeys = new Set<string>();
+function warnOnce(key: string, message: string) {
+  if (__DEV__ && !warnedOnceKeys.has(key)) {
+    warnedOnceKeys.add(key);
+    console.warn(message);
+  }
+}
+
 // Camera component
 const Camera = forwardRef<VisionCameraRefProps, VisionCameraProps>(
   (
@@ -34,6 +67,10 @@ const Camera = forwardRef<VisionCameraRefProps, VisionCameraProps>(
       style,
       enableFlash = false,
       zoomLevel = 1.0,
+      pinnedLensId,
+      zoomRatio,
+      torch,
+      focusMode = 'continuous',
       scanMode = 'photo',
       autoCapture = false,
       showCodeBoundingBoxes = false,
@@ -51,6 +88,7 @@ const Camera = forwardRef<VisionCameraRefProps, VisionCameraProps>(
       onSharpnessScoreUpdate = () => { },
       onBarcodeDetected = () => { },
       onBoundingBoxesUpdate = () => { },
+      onCameraStateChanged = () => { },
     },
     ref
   ) => {
@@ -65,12 +103,36 @@ const Camera = forwardRef<VisionCameraRefProps, VisionCameraProps>(
     const onSharpnessScoreUpdateRef = useRef(onSharpnessScoreUpdate);
     const onBarcodeDetectedRef = useRef(onBarcodeDetected);
     const onBoundingBoxesUpdateRef = useRef(onBoundingBoxesUpdate);
+    const onCameraStateChangedRef = useRef(onCameraStateChanged);
     onCaptureRef.current = onCapture;
     onErrorRef.current = onError;
     onRecognitionUpdateRef.current = onRecognitionUpdate;
     onSharpnessScoreUpdateRef.current = onSharpnessScoreUpdate;
     onBarcodeDetectedRef.current = onBarcodeDetected;
     onBoundingBoxesUpdateRef.current = onBoundingBoxesUpdate;
+    onCameraStateChangedRef.current = onCameraStateChanged;
+
+    // Prop collision resolution (Camera Controls API, spec §8): the canonical
+    // prop wins when both the deprecated and new prop are set. Distinguishing
+    // "explicitly passed" from "equals its default" isn't reliably knowable
+    // once destructured with defaults, so this is a best-effort heuristic
+    // (warns only when the deprecated prop's value diverges from its own
+    // default while the new prop is also present) — it will under-warn but
+    // will never over-warn on a consumer who only ever uses the new props.
+    const resolvedZoom = zoomRatio !== undefined ? zoomRatio : zoomLevel;
+    if (zoomRatio !== undefined && zoomLevel !== 1.0) {
+      warnOnce(
+        'zoom-collision',
+        '[VisionCamera] Both `zoomLevel` (deprecated) and `zoomRatio` are set — `zoomRatio` wins. Remove `zoomLevel`.'
+      );
+    }
+    const resolvedTorch = torch !== undefined ? torch : enableFlash;
+    if (torch !== undefined && enableFlash !== false) {
+      warnOnce(
+        'torch-collision',
+        '[VisionCamera] Both `enableFlash` (deprecated) and `torch` are set — `torch` wins. Remove `enableFlash`.'
+      );
+    }
 
     // Expose handlers via ref to parent components
     useImperativeHandle(ref, () => ({
@@ -121,6 +183,21 @@ const Camera = forwardRef<VisionCameraRefProps, VisionCameraProps>(
       setFocusSettings: (settings: FocusSettings) => {
         if (VisionCameraViewRef.current) {
           Commands.setFocusSettings(VisionCameraViewRef.current, JSON.stringify(settings));
+        }
+      },
+
+      // Named setTorchEnabled (not setTorch) on the native command layer to
+      // avoid an Android codegen collision with the `torch` prop's generated
+      // setTorch(view, boolean) setter — see src/specs/VisionCameraViewNativeComponent.ts.
+      setTorch: (enabled: boolean) => {
+        if (VisionCameraViewRef.current) {
+          Commands.setTorchEnabled(VisionCameraViewRef.current, enabled);
+        }
+      },
+
+      setFocusPoint: (x: number, y: number) => {
+        if (VisionCameraViewRef.current) {
+          Commands.setFocusPoint(VisionCameraViewRef.current, x, y);
         }
       },
 
@@ -206,13 +283,25 @@ const Camera = forwardRef<VisionCameraRefProps, VisionCameraProps>(
       []
     )
 
+    const onCameraStateChangedHandler = useCallback(
+      (event: any) =>
+        onCameraStateChangedRef.current(
+          normalizeCameraStateEvent(parseNativeEvent<VisionCameraStateEvent>(event))
+        ),
+      []
+    )
+
     return (
       <>
         <VisionCameraView
           ref={VisionCameraViewRef}
           style={[styles.flex, style]}
-          enableFlash={enableFlash}
-          zoomLevel={zoomLevel}
+          enableFlash={resolvedTorch}
+          zoomLevel={resolvedZoom}
+          zoomRatio={resolvedZoom}
+          torch={resolvedTorch}
+          pinnedLensId={pinnedLensId}
+          focusMode={focusMode}
           scanMode={scanMode}
           autoCapture={autoCapture}
           showCodeBoundingBoxes={showCodeBoundingBoxes}
@@ -230,6 +319,7 @@ const Camera = forwardRef<VisionCameraRefProps, VisionCameraProps>(
           onSharpnessScoreUpdate={onSharpnessScoreUpdateHandler}
           onBarcodeDetected={onBarcodeDetectedHandler}
           onBoundingBoxesUpdate={onBoundingBoxesUpdateHandler}
+          onCameraStateChanged={onCameraStateChangedHandler}
         />
         {children}
       </>

--- a/src/VisionCameraTypes.ts
+++ b/src/VisionCameraTypes.ts
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { StyleProp, ViewStyle } from 'react-native';
-import type { TemplateData } from './types';
+import type { CameraErrorCode, CameraStatus, FocusMode, LensFacing, TemplateData } from './types';
 
 /**
  * Camera scan mode types
@@ -14,9 +14,11 @@ export type VisionCameraScanMode =
   | 'barcodesinglecapture';
 
 /**
- * Camera facing direction types
+ * Camera facing direction types.
+ * Alias of `LensFacing` (`./types`) — kept as a separate exported name for
+ * backwards compatibility with existing consumers of this file.
  */
-export type CameraFacing = 'back' | 'front';
+export type CameraFacing = LensFacing;
 
 /**
  * Event triggered when an image is captured by the camera.
@@ -359,6 +361,94 @@ export interface VisionCameraBoundingBoxesUpdateEvent {
 }
 
 /**
+ * Event payload for the throttled (≤10Hz) camera-state stream (Camera Controls
+ * API, Phase 3). Fires once immediately on listener attach with the current
+ * state (replay), and status/error/warning transitions always bypass the
+ * throttle.
+ */
+export interface VisionCameraStateEvent {
+  /**
+   * @type {CameraStatus}
+   * @description Current camera session status.
+   */
+  status: CameraStatus;
+
+  /**
+   * @type {CameraErrorCode | undefined}
+   * @description Fatal error code, only set when `status === 'error'`.
+   */
+  errorCode?: CameraErrorCode;
+
+  /**
+   * @type {string | undefined}
+   * @description Human-readable message for `errorCode`.
+   */
+  errorMessage?: string;
+
+  /**
+   * @type {CameraErrorCode | undefined}
+   * @description Non-fatal warning code (e.g. an unpinnable `pinnedLensId` falling back to Auto).
+   */
+  warningCode?: CameraErrorCode;
+
+  /**
+   * @type {string | undefined}
+   * @description Human-readable message for `warningCode`.
+   */
+  warningMessage?: string;
+
+  /**
+   * @type {CameraFacing}
+   * @description Which physical camera position is currently active.
+   */
+  facing: CameraFacing;
+
+  /**
+   * @type {string | undefined}
+   * @description Id of the currently active lens (from `getCameraCapabilities()`), if known.
+   */
+  activeLensId?: string;
+
+  /**
+   * @type {number}
+   * @description Current wide-normalized zoom ratio.
+   */
+  zoomRatio: number;
+
+  /**
+   * @type {number}
+   * @description Minimum zoom ratio supported by the active lens/facing.
+   */
+  minZoomRatio: number;
+
+  /**
+   * @type {number}
+   * @description Maximum zoom ratio supported by the active lens/facing.
+   */
+  maxZoomRatio: number;
+
+  /**
+   * @type {boolean}
+   * @description Whether the torch/flash is currently on.
+   */
+  torchEnabled: boolean;
+
+  /**
+   * @type {FocusMode}
+   * @description Currently active focus mode.
+   */
+  focusMode: FocusMode;
+
+  /**
+   * @type {boolean}
+   * @description Whether the camera preview is actively rendering frames.
+   * Ratified as part of this single throttled event — there is no separate
+   * `onCameraReady` event.
+   */
+  isPreviewActive: boolean;
+}
+
+/**
  * Props for the Vision Camera view component.
  */
 export interface VisionCameraViewProps {
@@ -380,6 +470,8 @@ export interface VisionCameraViewProps {
    * @optional
    * @type {boolean}
    * @description Optional flag to enable or disable flash for capturing.
+   * @deprecated Use `torch` instead. Feeds the same native path — if both are
+   * set, `torch` wins and a one-time dev warning fires.
    */
   enableFlash?: boolean;
 
@@ -387,8 +479,59 @@ export interface VisionCameraViewProps {
    * @optional
    * @type {number}
    * @description Optional zoom level for the camera.
+   * @deprecated Use `zoomRatio` instead. Feeds the same native path — if both
+   * are set, `zoomRatio` wins and a one-time dev warning fires.
    */
   zoomLevel?: number;
+
+  /**
+   * @optional
+   * @type {string | undefined}
+   * @description Pin a specific lens by id (from `VisionCore.getCameraCapabilities()`).
+   * Undefined = Auto (OS picks the physical lens per zoom, default behavior).
+   * An unknown or unpinnable id resolves to Auto with `warningCode: 'lens-unavailable'`
+   * in the next `onCameraStateChanged` event — never a native throw.
+   */
+  pinnedLensId?: string;
+
+  /**
+   * @optional
+   * @type {number | undefined}
+   * @description Canonical zoom control. Wide-normalized absolute ratio: 1.0 = wide
+   * lens at 1x, 0.5 = ultra-wide, 3.0 = telephoto territory — identical meaning on
+   * both platforms. Supersedes the deprecated `zoomLevel` (same native path; if both
+   * are set, `zoomRatio` wins and a one-time dev warning fires).
+   * @default 1.0
+   */
+  zoomRatio?: number;
+
+  /**
+   * @optional
+   * @type {boolean | undefined}
+   * @description Canonical torch control. Supersedes the deprecated `enableFlash`
+   * (same native path; if both are set, `torch` wins and a one-time dev warning fires).
+   * @default false
+   */
+  torch?: boolean;
+
+  /**
+   * @optional
+   * @type {FocusMode | undefined}
+   * @description Camera focus mode: 'continuous' (AF-C), 'single' (AF-S), or 'locked'.
+   * @default 'continuous'
+   */
+  focusMode?: FocusMode;
+
+  /**
+   * @optional
+   * @param {VisionCameraStateEvent} event
+   * @description Event handler for the throttled (≤10Hz) camera-state stream —
+   * status, facing, active lens, zoom range, torch, focus mode, and any non-fatal
+   * warning (e.g. an unpinnable `pinnedLensId` falling back to Auto). Fires once
+   * immediately on attach with the current state (replay), and status/error/warning
+   * transitions always bypass the throttle.
+   */
+  onCameraStateChanged?: (event: VisionCameraStateEvent) => void;
 
   /**
    * @optional
@@ -703,6 +846,22 @@ export interface VisionCameraRefProps {
   setFocusSettings: (settings: FocusSettings) => void;
 
   /**
+   * Sets the torch (flash) on/off. Fire-and-forget — the result lands in the
+   * next `onCameraStateChanged` event's `torchEnabled` field.
+   * @param {boolean} enabled - Whether the torch should be on.
+   */
+  setTorch: (enabled: boolean) => void;
+
+  /**
+   * Triggers a one-shot focus+metering pass at the given point (normalized 0-1,
+   * top-left origin), under whatever `focusMode` is currently set. Does not
+   * change `focusMode` itself.
+   * @param {number} x - Normalized x coordinate (0-1).
+   * @param {number} y - Normalized y coordinate (0-1).
+   */
+  setFocusPoint: (x: number, y: number) => void;
+
+  /**
    * Pauses detection while keeping the camera session/preview alive.
    * @description Mode-agnostic universal pause: stops the underlying
    * per-frame Vision/CoreML (iOS) or MLKit/ONNX (Android) analysis work
@@ -749,6 +908,8 @@ export interface VisionCameraProps {
    * @optional
    * @type {boolean | undefined}
    * @description Optional flag to enable or disable flash for capturing.
+   * @deprecated Use `torch` instead. Feeds the same native path — if both are
+   * set, `torch` wins and a one-time dev warning fires.
    */
   enableFlash?: boolean;
 
@@ -756,8 +917,59 @@ export interface VisionCameraProps {
    * @optional
    * @type {number | undefined}
    * @description Optional zoom level for the camera.
+   * @deprecated Use `zoomRatio` instead. Feeds the same native path — if both
+   * are set, `zoomRatio` wins and a one-time dev warning fires.
    */
   zoomLevel?: number;
+
+  /**
+   * @optional
+   * @type {string | undefined}
+   * @description Pin a specific lens by id (from `VisionCore.getCameraCapabilities()`).
+   * Undefined = Auto (OS picks the physical lens per zoom, default behavior).
+   * An unknown or unpinnable id resolves to Auto with `warningCode: 'lens-unavailable'`
+   * in the next `onCameraStateChanged` event — never a native throw.
+   */
+  pinnedLensId?: string;
+
+  /**
+   * @optional
+   * @type {number | undefined}
+   * @description Canonical zoom control. Wide-normalized absolute ratio: 1.0 = wide
+   * lens at 1x, 0.5 = ultra-wide, 3.0 = telephoto territory — identical meaning on
+   * both platforms. Supersedes the deprecated `zoomLevel` (same native path; if both
+   * are set, `zoomRatio` wins and a one-time dev warning fires).
+   * @default 1.0
+   */
+  zoomRatio?: number;
+
+  /**
+   * @optional
+   * @type {boolean | undefined}
+   * @description Canonical torch control. Supersedes the deprecated `enableFlash`
+   * (same native path; if both are set, `torch` wins and a one-time dev warning fires).
+   * @default false
+   */
+  torch?: boolean;
+
+  /**
+   * @optional
+   * @type {FocusMode | undefined}
+   * @description Camera focus mode: 'continuous' (AF-C), 'single' (AF-S), or 'locked'.
+   * @default 'continuous'
+   */
+  focusMode?: FocusMode;
+
+  /**
+   * @optional
+   * @param {VisionCameraStateEvent} event
+   * @description Event handler for the throttled (≤10Hz) camera-state stream —
+   * status, facing, active lens, zoom range, torch, focus mode, and any non-fatal
+   * warning (e.g. an unpinnable `pinnedLensId` falling back to Auto). Fires once
+   * immediately on attach with the current state (replay), and status/error/warning
+   * transitions always bypass the throttle.
+   */
+  onCameraStateChanged?: (event: VisionCameraStateEvent) => void;
 
   /**
    * @optional

--- a/src/VisionCoreWrapper.ts
+++ b/src/VisionCoreWrapper.ts
@@ -7,6 +7,7 @@ import type {
   DownloadProgress,
   ModelInfo,
   DetectedBarcode,
+  CameraCapabilities,
 } from './types';
 
 // New Architecture only - use TurboModule
@@ -667,6 +668,31 @@ export const VisionCore = {
       return parsedResult;
     } catch (error) {
       throw error;
+    }
+  },
+
+  // ============================================================================
+  // CAMERA CONTROLS API (Phase 3)
+  // ============================================================================
+
+  /**
+   * Snapshots the device's current camera capabilities (lenses, zoom stops,
+   * torch/focus support) for both facings.
+   *
+   * @returns CameraCapabilities describing all lenses and per-facing support.
+   *
+   * @example
+   * const capabilities = await VisionCore.getCameraCapabilities();
+   * console.log(capabilities.lenses.map((lens) => lens.id));
+   */
+  getCameraCapabilities: async (): Promise<CameraCapabilities> => {
+    const result = await VisionSdkModuleNative.getCameraCapabilities();
+    try {
+      return JSON.parse(result);
+    } catch (error) {
+      throw new Error(
+        `VisionCore.getCameraCapabilities: failed to parse native response as JSON: ${error}`
+      );
     }
   },
 

--- a/src/__tests__/VisionCamera.cameraControls.test.tsx
+++ b/src/__tests__/VisionCamera.cameraControls.test.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { create, act, ReactTestRenderer } from 'react-test-renderer';
+
+// Mock the native component before importing anything that uses it — matches
+// the harness style in src/__tests__/index.test.tsx.
+jest.mock('../specs/VisionCameraViewNativeComponent', () => {
+  const { forwardRef } = require('react');
+  const MockNativeComponent = forwardRef((props: any, ref: any) => {
+    const { View } = require('react-native');
+    return <View ref={ref} {...props} />;
+  });
+  MockNativeComponent.displayName = 'MockVisionCameraViewNative';
+  return {
+    __esModule: true,
+    default: MockNativeComponent,
+    Commands: {
+      capture: jest.fn(),
+      stop: jest.fn(),
+      start: jest.fn(),
+      rescan: jest.fn(),
+      toggleFlash: jest.fn(),
+      setZoom: jest.fn(),
+      setFocusSettings: jest.fn(),
+      pauseDetection: jest.fn(),
+      resumeDetection: jest.fn(),
+      setTorchEnabled: jest.fn(),
+      setFocusPoint: jest.fn(),
+    },
+  };
+});
+
+import { VisionCamera } from '../VisionCamera';
+import { VisionCameraView } from '../VisionCameraViewManager';
+
+function renderInAct(element: React.ReactElement): ReactTestRenderer {
+  let tree: ReactTestRenderer;
+  act(() => {
+    tree = create(element);
+  });
+  return tree!;
+}
+
+describe('VisionCamera camera-controls prop collisions (spec §8)', () => {
+  it('warns exactly once when both zoomLevel (deprecated) and zoomRatio are set, and forwards the canonical zoomRatio to the native view', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => { });
+
+    const tree1 = renderInAct(<VisionCamera zoomLevel={2.0} zoomRatio={3.0} />);
+    // A second, independent VisionCamera instance with the same collision —
+    // the warning is a module-level "warn once" (not per-instance), so it
+    // must still only have fired a single time overall.
+    renderInAct(<VisionCamera zoomLevel={2.0} zoomRatio={3.0} />);
+
+    const viewProps = tree1.root.findByType(VisionCameraView as any).props;
+    expect(viewProps.zoomRatio).toBe(3.0);
+    expect(viewProps.zoomLevel).toBe(3.0);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]![0]).toContain('zoomRatio` wins');
+
+    warnSpy.mockRestore();
+  });
+
+  it('warns exactly once when both enableFlash (deprecated) and torch are set, and forwards the canonical torch value to the native view', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => { });
+
+    const tree = renderInAct(<VisionCamera enableFlash={true} torch={false} />);
+    // Re-render with the same collision — still only warns once.
+    act(() => {
+      tree.update(<VisionCamera enableFlash={true} torch={false} />);
+    });
+
+    const viewProps = tree.root.findByType(VisionCameraView as any).props;
+    expect(viewProps.torch).toBe(false);
+    expect(viewProps.enableFlash).toBe(false);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]![0]).toContain('torch` wins');
+
+    warnSpy.mockRestore();
+  });
+});
+
+describe('VisionCamera pinnedLensId fallback (spec §5.3/§8)', () => {
+  it('never throws for an unpinnable/unknown lens id — resolution happens natively, the JS layer just renders', () => {
+    expect(() => {
+      renderInAct(<VisionCamera pinnedLensId="not-a-real-lens" />);
+    }).not.toThrow();
+  });
+
+  it('surfaces the native lens-unavailable fallback warning through onCameraStateChanged (Android shape: warningMessage omitted)', () => {
+    const onCameraStateChanged = jest.fn();
+    const tree = renderInAct(
+      <VisionCamera pinnedLensId="not-a-real-lens" onCameraStateChanged={onCameraStateChanged} />
+    );
+    const viewProps = tree.root.findByType(VisionCameraView as any).props;
+
+    act(() => {
+      viewProps.onCameraStateChanged({
+        nativeEvent: {
+          status: 'running',
+          facing: 'back',
+          zoomRatio: 1,
+          minZoomRatio: 1,
+          maxZoomRatio: 4,
+          torchEnabled: false,
+          focusMode: 'continuous',
+          isPreviewActive: true,
+          warningCode: 'lens-unavailable',
+          // Android omits warningMessage entirely rather than sending ''.
+        },
+      });
+    });
+
+    expect(onCameraStateChanged).toHaveBeenCalledTimes(1);
+    const event = onCameraStateChanged.mock.calls[0][0];
+    expect(event.warningCode).toBe('lens-unavailable');
+    expect(event.warningMessage).toBeUndefined();
+    expect(event.status).toBe('running'); // never a thrown exception, never status: 'error'
+  });
+
+  it('surfaces the native lens-unavailable fallback warning through onCameraStateChanged (iOS shape: absent warningMessage sent as \'\', normalized to undefined)', () => {
+    const onCameraStateChanged = jest.fn();
+    const tree = renderInAct(
+      <VisionCamera pinnedLensId="not-a-real-lens" onCameraStateChanged={onCameraStateChanged} />
+    );
+    const viewProps = tree.root.findByType(VisionCameraView as any).props;
+
+    act(() => {
+      viewProps.onCameraStateChanged({
+        nativeEvent: {
+          status: 'running',
+          facing: 'back',
+          zoomRatio: 1,
+          minZoomRatio: 1,
+          maxZoomRatio: 4,
+          torchEnabled: false,
+          focusMode: 'continuous',
+          isPreviewActive: true,
+          warningCode: 'lens-unavailable',
+          // iOS's Fabric typed emitter sends absent optional strings as '""'
+          // rather than omitting the field — must normalize to undefined
+          // identically to the Android (field-omitted) shape above.
+          warningMessage: '',
+        },
+      });
+    });
+
+    expect(onCameraStateChanged).toHaveBeenCalledTimes(1);
+    const event = onCameraStateChanged.mock.calls[0][0];
+    expect(event.warningCode).toBe('lens-unavailable');
+    expect(event.warningMessage).toBeUndefined();
+  });
+});

--- a/src/__tests__/VisionCoreWrapper.cameraCapabilities.test.ts
+++ b/src/__tests__/VisionCoreWrapper.cameraCapabilities.test.ts
@@ -1,0 +1,56 @@
+// Mock the native TurboModule before importing anything that uses it
+jest.mock('../specs/NativeVisionSdkModule', () => ({
+  __esModule: true,
+  default: {
+    getCameraCapabilities: jest.fn(),
+    addListener: jest.fn(),
+    removeListeners: jest.fn(),
+  },
+}));
+
+import { VisionCore } from '../VisionCoreWrapper';
+import NativeVisionSdkModule from '../specs/NativeVisionSdkModule';
+
+describe('VisionCore.getCameraCapabilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('parses the native JSON response into a typed CameraCapabilities object', async () => {
+    const capabilities = {
+      lenses: [
+        {
+          id: 'back-wide',
+          kind: 'wide',
+          facing: 'back',
+          minZoomRatio: 1,
+          maxZoomRatio: 10,
+          zoomSwitchPoints: [2, 5],
+          hasFlash: true,
+          isLogical: false,
+          isPinnable: true,
+        },
+      ],
+      zoomStops: { back: [1, 2, 5], front: [1] },
+      hasTorch: { back: true, front: false },
+      supportsFocusPoint: { back: true, front: true },
+    };
+    (NativeVisionSdkModule.getCameraCapabilities as jest.Mock).mockResolvedValue(
+      JSON.stringify(capabilities)
+    );
+
+    const result = await VisionCore.getCameraCapabilities();
+
+    expect(result).toEqual(capabilities);
+  });
+
+  it('rejects with a clear message when the native response is not valid JSON', async () => {
+    (NativeVisionSdkModule.getCameraCapabilities as jest.Mock).mockResolvedValue(
+      'not valid json{{{'
+    );
+
+    await expect(VisionCore.getCameraCapabilities()).rejects.toThrow(
+      'VisionCore.getCameraCapabilities'
+    );
+  });
+});

--- a/src/__tests__/useCameraControls.test.tsx
+++ b/src/__tests__/useCameraControls.test.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { create, act } from 'react-test-renderer';
+
+// This repo has no @testing-library/react-hooks dependency (it's not
+// installed and doesn't support this repo's React 19 pin), so this test
+// drives the hook the same way src/__tests__/index.test.tsx drives
+// components: mount a harness with react-test-renderer, capture the hook's
+// return value on each render, and assert on it inside `act`.
+
+// getCameraCapabilities() is intentionally never resolved here — these tests
+// only assert on the synchronous reset-to-`undefined` behavior on view-instance
+// change, not on the fetched value, and leaving it pending avoids a stray
+// "state update not wrapped in act" warning from a resolution firing after
+// the test body returns.
+jest.mock('../VisionCoreWrapper', () => ({
+  VisionCore: {
+    getCameraCapabilities: jest.fn(() => new Promise(() => { })),
+  },
+}));
+
+import { useCameraControls } from '../camera-controls/useCameraControls';
+import type { VisionCameraStateEvent } from '../VisionCameraTypes';
+
+type Controls = ReturnType<typeof useCameraControls>;
+
+function Harness({ onRender }: { onRender: (controls: Controls) => void }) {
+  const controls = useCameraControls();
+  onRender(controls);
+  return null;
+}
+
+function renderCameraControls(): { current: Controls } {
+  const holder: { current: Controls | null } = { current: null };
+  act(() => {
+    create(
+      <Harness
+        onRender={(controls) => {
+          holder.current = controls;
+        }}
+      />
+    );
+  });
+  return holder as { current: Controls };
+}
+
+function attach(hook: { current: Controls }, instance: any) {
+  act(() => {
+    (hook.current.ref as any)(instance);
+  });
+}
+
+const runningState: VisionCameraStateEvent = {
+  status: 'running',
+  facing: 'back',
+  zoomRatio: 1,
+  minZoomRatio: 1,
+  maxZoomRatio: 4,
+  torchEnabled: false,
+  focusMode: 'continuous',
+  isPreviewActive: true,
+};
+
+describe('useCameraControls', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('starts with state and capabilities undefined', () => {
+    const hook = renderCameraControls();
+    expect(hook.current.state).toBeUndefined();
+    expect(hook.current.capabilities).toBeUndefined();
+  });
+
+  it('resets state and capabilities when the underlying view instance changes, then repopulates from the new instance\'s events', () => {
+    const hook = renderCameraControls();
+
+    const instanceA = {
+      setZoom: jest.fn(),
+      setTorch: jest.fn(),
+      setFocusPoint: jest.fn(),
+    } as any;
+    attach(hook, instanceA);
+    act(() => {
+      hook.current.onCameraStateChanged(runningState);
+    });
+    expect(hook.current.state?.status).toBe('running');
+    expect(hook.current.state?.zoomRatio).toBe(1);
+
+    const instanceB = {
+      setZoom: jest.fn(),
+      setTorch: jest.fn(),
+      setFocusPoint: jest.fn(),
+    } as any;
+    attach(hook, instanceB);
+    expect(hook.current.state).toBeUndefined();
+    expect(hook.current.capabilities).toBeUndefined();
+
+    // Repopulation: the new instance's own state event lands and is reported
+    // verbatim — never a stale carryover from instanceA (whose zoomRatio was 1).
+    act(() => {
+      hook.current.onCameraStateChanged({ ...runningState, zoomRatio: 2 });
+    });
+    expect(hook.current.state).toBeDefined();
+    expect(hook.current.state?.zoomRatio).toBe(2);
+  });
+
+  it('reports the state event\'s zoomRatio verbatim even when it differs from the requested value (state truthfulness)', () => {
+    const hook = renderCameraControls();
+    const instance = {
+      setZoom: jest.fn(),
+      setTorch: jest.fn(),
+      setFocusPoint: jest.fn(),
+    } as any;
+    attach(hook, instance);
+
+    act(() => {
+      hook.current.setZoom(5.0);
+    });
+    expect(instance.setZoom).toHaveBeenCalledWith(5.0);
+
+    // Native clamps the requested 5.0 down to 4.2 and reports that in the
+    // next state event — the hook is a pure passthrough of whatever the
+    // native layer reports, it never second-guesses or echoes the request.
+    act(() => {
+      hook.current.onCameraStateChanged({ ...runningState, zoomRatio: 4.2 });
+    });
+
+    expect(hook.current.state?.zoomRatio).toBe(4.2);
+  });
+
+  it('populates state immediately when a replay event fires synchronously on ref attach (never observably stale-undefined)', () => {
+    const renderedStates: Array<VisionCameraStateEvent | undefined> = [];
+    const holder: { current: Controls | null } = { current: null };
+    act(() => {
+      create(
+        <Harness
+          onRender={(controls) => {
+            holder.current = controls;
+            renderedStates.push(controls.state);
+          }}
+        />
+      );
+    });
+    expect(renderedStates).toEqual([undefined]); // initial mount, no camera attached yet
+
+    const instance = {
+      setZoom: jest.fn(),
+      setTorch: jest.fn(),
+      setFocusPoint: jest.fn(),
+    } as any;
+
+    // Simulates the real native replay-on-attach behavior (Tasks 13/17): the
+    // view emits its current state synchronously as soon as the listener is
+    // wired up, in the same tick as ref attach.
+    act(() => {
+      (holder.current!.ref as any)(instance);
+      holder.current!.onCameraStateChanged(runningState);
+    });
+
+    // React 18+ batches both synchronous updates from the same act() call
+    // into a single commit — a consumer of this hook never observes an
+    // intermediate "reset to undefined, then repopulated" render.
+    expect(renderedStates).toEqual([undefined, runningState]);
+    expect(holder.current!.state).toEqual(runningState);
+  });
+
+  it('setZoom/setTorch/setFocusPoint call through to the attached ref instance', () => {
+    const hook = renderCameraControls();
+    const instance = {
+      setZoom: jest.fn(),
+      setTorch: jest.fn(),
+      setFocusPoint: jest.fn(),
+    } as any;
+    attach(hook, instance);
+
+    act(() => {
+      hook.current.setZoom(2.5);
+      hook.current.setTorch(true);
+      hook.current.setFocusPoint(0.4, 0.6);
+    });
+
+    expect(instance.setZoom).toHaveBeenCalledWith(2.5);
+    expect(instance.setTorch).toHaveBeenCalledWith(true);
+    expect(instance.setFocusPoint).toHaveBeenCalledWith(0.4, 0.6);
+  });
+});

--- a/src/__tests__/useCameraControls.test.tsx
+++ b/src/__tests__/useCameraControls.test.tsx
@@ -19,6 +19,7 @@ jest.mock('../VisionCoreWrapper', () => ({
 }));
 
 import { useCameraControls } from '../camera-controls/useCameraControls';
+import { VisionCore } from '../VisionCoreWrapper';
 import type { VisionCameraStateEvent } from '../VisionCameraTypes';
 
 type Controls = ReturnType<typeof useCameraControls>;
@@ -162,6 +163,33 @@ describe('useCameraControls', () => {
     // intermediate "reset to undefined, then repopulated" render.
     expect(renderedStates).toEqual([undefined, runningState]);
     expect(holder.current!.state).toEqual(runningState);
+  });
+
+  it('ignores a stale capabilities fetch that resolves after a newer view attached', async () => {
+    // The two fetches are resolved out of order (newer first, then the older
+    // detached one) — the case that would corrupt capabilities *permanently*,
+    // not just briefly, if the result weren't matched back to its instance.
+    let resolveA: (caps: any) => void = () => { };
+    let resolveB: (caps: any) => void = () => { };
+    (VisionCore.getCameraCapabilities as jest.Mock)
+      .mockImplementationOnce(() => new Promise((res) => { resolveA = res; }))
+      .mockImplementationOnce(() => new Promise((res) => { resolveB = res; }));
+
+    const hook = renderCameraControls();
+    const makeInstance = () =>
+      ({ setZoom: jest.fn(), setTorch: jest.fn(), setFocusPoint: jest.fn() }) as any;
+
+    attach(hook, makeInstance()); // instance A -> fetch A
+    attach(hook, makeInstance()); // instance B -> fetch B (A now detached)
+
+    const capsA = { maxZoomRatio: 4 } as any;
+    const capsB = { maxZoomRatio: 8 } as any;
+
+    await act(async () => { resolveB(capsB); });
+    await act(async () => { resolveA(capsA); });
+
+    // A's late result belongs to a detached view and must be dropped.
+    expect(hook.current.capabilities).toBe(capsB);
   });
 
   it('setZoom/setTorch/setFocusPoint call through to the attached ref instance', () => {

--- a/src/camera-controls/useCameraControls.ts
+++ b/src/camera-controls/useCameraControls.ts
@@ -53,8 +53,16 @@ export function useCameraControls(): {
       setState(undefined);
       setCapabilities(undefined);
       if (instance) {
+        // Capture the instance this fetch belongs to. Without it, a slow fetch for
+        // a detached view can resolve after a newer view attached and overwrite the
+        // newer capabilities — permanently, if the two responses land out of order.
+        const fetchedFor = instance;
         VisionCore.getCameraCapabilities()
-          .then((caps) => setCapabilities(caps))
+          .then((caps) => {
+            if (instanceRef.current === fetchedFor) {
+              setCapabilities(caps);
+            }
+          })
           .catch((err) => {
             // Capabilities are best-effort; the state stream remains authoritative.
             console.warn('[useCameraControls] getCameraCapabilities failed:', err);

--- a/src/camera-controls/useCameraControls.ts
+++ b/src/camera-controls/useCameraControls.ts
@@ -1,0 +1,93 @@
+import { useCallback, useRef, useState } from 'react';
+import type { RefCallback, RefObject } from 'react';
+import { VisionCore } from '../VisionCoreWrapper';
+import type { VisionCameraRefProps, VisionCameraStateEvent } from '../VisionCameraTypes';
+import type { CameraCapabilities } from '../types';
+
+/**
+ * Primary documented entry point for the Camera Controls API (spec §8).
+ * Owns the wiring between `<VisionCamera>` and application state:
+ *
+ * ```tsx
+ * const camera = useCameraControls();
+ * <VisionCamera ref={camera.ref} onCameraStateChanged={camera.onCameraStateChanged} />
+ * ```
+ *
+ * Resets `state`/`capabilities` to `undefined` whenever the underlying view
+ * instance changes (e.g. a keyed remount), so a fresh view never briefly
+ * renders its predecessor's state — the replay event (native side, on
+ * listener attach) repopulates `state` immediately after.
+ */
+export function useCameraControls(): {
+  ref: RefCallback<VisionCameraRefProps>;
+  /**
+   * Review fix (API shape) — `ref` above is a callback ref: correct to hand to
+   * `<VisionCamera ref={camera.ref} />`, but consumers can't read `.current` off
+   * a callback ref, which the old (dishonest) `ref: RefObject<...>` typing implied
+   * they could — `camera.ref.current` was always undefined. `cameraRef` is a real
+   * `RefObject`, kept in sync inside the same callback below, for consumers who
+   * need imperative access beyond setZoom/setTorch/setFocusPoint (e.g.
+   * capture/start/stop/rescan).
+   */
+  cameraRef: RefObject<VisionCameraRefProps | null>;
+  onCameraStateChanged: (event: VisionCameraStateEvent) => void;
+  state: VisionCameraStateEvent | undefined;
+  capabilities: CameraCapabilities | undefined;
+  setZoom: (ratio: number) => void;
+  setTorch: (on: boolean) => void;
+  setFocusPoint: (x: number, y: number) => void;
+} {
+  const [state, setState] = useState<VisionCameraStateEvent | undefined>(undefined);
+  const [capabilities, setCapabilities] = useState<CameraCapabilities | undefined>(undefined);
+  const instanceRef = useRef<VisionCameraRefProps | null>(null);
+
+  // A plain RefObject can't observe attach/detach transitions — only a
+  // callback ref can, and resetting state/capabilities on view-instance
+  // change requires observing that transition. Callback refs are assignable
+  // wherever a `ref` prop is expected on a forwardRef component, so this is
+  // safe to hand to <VisionCamera ref={camera.ref} />. `instanceRef` (exposed
+  // below as `cameraRef`) is kept in sync here so consumers who need a real
+  // `.current` (not just this hook's setZoom/setTorch/setFocusPoint) have one.
+  const ref = useCallback((instance: VisionCameraRefProps | null) => {
+    if (instance !== instanceRef.current) {
+      setState(undefined);
+      setCapabilities(undefined);
+      if (instance) {
+        VisionCore.getCameraCapabilities()
+          .then((caps) => setCapabilities(caps))
+          .catch((err) => {
+            // Capabilities are best-effort; the state stream remains authoritative.
+            console.warn('[useCameraControls] getCameraCapabilities failed:', err);
+          });
+      }
+    }
+    instanceRef.current = instance;
+  }, []);
+
+  const onCameraStateChanged = useCallback((event: VisionCameraStateEvent) => {
+    setState(event);
+  }, []);
+
+  const setZoom = useCallback((ratio: number) => {
+    instanceRef.current?.setZoom(ratio);
+  }, []);
+
+  const setTorch = useCallback((on: boolean) => {
+    instanceRef.current?.setTorch(on);
+  }, []);
+
+  const setFocusPoint = useCallback((x: number, y: number) => {
+    instanceRef.current?.setFocusPoint(x, y);
+  }, []);
+
+  return {
+    ref,
+    cameraRef: instanceRef,
+    onCameraStateChanged,
+    state,
+    capabilities,
+    setZoom,
+    setTorch,
+    setFocusPoint,
+  };
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,3 +3,4 @@ export * from './VisionCore';
 export { VisionCamera } from './VisionCamera';
 export * from './VisionCameraTypes';
 export * from './dimensioning';
+export { useCameraControls } from './camera-controls/useCameraControls';

--- a/src/specs/NativeVisionSdkModule.ts
+++ b/src/specs/NativeVisionSdkModule.ts
@@ -341,6 +341,13 @@ export interface Spec extends TurboModule {
   ): Promise<string>;
 
   /**
+   * Snapshots the device's current camera capabilities (lenses, zoom stops,
+   * torch/focus support) for both facings.
+   * @returns CameraCapabilities as a JSON string (see src/types.ts `CameraCapabilities`)
+   */
+  getCameraCapabilities(): Promise<string>;
+
+  /**
    * Adds a listener for the specified event
    * This is required for TurboModule event emitters
    */

--- a/src/specs/VisionCameraViewNativeComponent.ts
+++ b/src/specs/VisionCameraViewNativeComponent.ts
@@ -50,6 +50,25 @@ type BoundingBoxesUpdateEvent = Readonly<{
   }>;
 }>;
 
+// Camera Controls API (Phase 3) — throttled full-state event (§8). isPreviewActive is
+// folded into this single event per the ratified "one throttled RN event" decision;
+// there is no separate onCameraReady event.
+type CameraStateChangedEvent = Readonly<{
+  status?: string; // CameraStatus: 'idle' | 'starting' | 'running' | 'interrupted' | 'error'
+  errorCode?: string; // CameraErrorCode
+  errorMessage?: string;
+  warningCode?: string; // CameraErrorCode
+  warningMessage?: string;
+  facing?: string; // LensFacing: 'back' | 'front'
+  activeLensId?: string;
+  zoomRatio?: Float;
+  minZoomRatio?: Float;
+  maxZoomRatio?: Float;
+  torchEnabled?: boolean;
+  focusMode?: string; // FocusMode: 'continuous' | 'single' | 'locked'
+  isPreviewActive?: boolean;
+}>;
+
 // Component props interface
 export interface NativeProps extends ViewProps {
   // Boolean properties
@@ -70,6 +89,13 @@ export interface NativeProps extends ViewProps {
   scanMode?: WithDefault<string, 'photo'>; // 'photo' | 'barcode' | 'qrcode' | 'barcodeorqrcode' | 'ocr' | 'barcodesinglecapture'
   cameraFacing?: WithDefault<string, 'back'>; // 'back' | 'front'
 
+  // Camera Controls API (Phase 3) — canonical props; zoomLevel/enableFlash above stay as
+  // deprecated aliases feeding the same native path (see VisionCamera.tsx).
+  pinnedLensId?: string; // undefined = Auto
+  zoomRatio?: WithDefault<Double, 1.0>;
+  torch?: WithDefault<boolean, false>;
+  focusMode?: WithDefault<string, 'continuous'>; // FocusMode
+
   // Object properties - passed as JSON strings due to codegen limitations
   scanAreaJson?: string;
   detectionConfigJson?: string;
@@ -82,6 +108,7 @@ export interface NativeProps extends ViewProps {
   onSharpnessScoreUpdate?: DirectEventHandler<SharpnessScoreUpdateEvent>;
   onBarcodeDetected?: DirectEventHandler<BarcodeDetectedEvent>;
   onBoundingBoxesUpdate?: DirectEventHandler<BoundingBoxesUpdateEvent>;
+  onCameraStateChanged?: DirectEventHandler<CameraStateChangedEvent>;
 }
 
 // Native commands interface
@@ -95,10 +122,16 @@ interface NativeCommands {
   setFocusSettings: (viewRef: React.ElementRef<HostComponent<NativeProps>>, settingsJson: string) => void;
   pauseDetection: (viewRef: React.ElementRef<HostComponent<NativeProps>>) => void;
   resumeDetection: (viewRef: React.ElementRef<HostComponent<NativeProps>>) => void;
+  // NOTE: named setTorchEnabled (not setTorch) to avoid an Android codegen collision — the
+  // `torch` prop already generates `setTorch(view, boolean)` on VisionCameraViewManagerInterface;
+  // a same-named command with the same erased signature (view, boolean) fails javac
+  // ("method already defined"). Verified via `javac` repro during Task 9 codegen regen.
+  setTorchEnabled: (viewRef: React.ElementRef<HostComponent<NativeProps>>, enabled: boolean) => void;
+  setFocusPoint: (viewRef: React.ElementRef<HostComponent<NativeProps>>, x: Float, y: Float) => void;
 }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
-  supportedCommands: ['capture', 'stop', 'start', 'rescan', 'toggleFlash', 'setZoom', 'setFocusSettings', 'pauseDetection', 'resumeDetection'],
+  supportedCommands: ['capture', 'stop', 'start', 'rescan', 'toggleFlash', 'setZoom', 'setFocusSettings', 'pauseDetection', 'resumeDetection', 'setTorchEnabled', 'setFocusPoint'],
 });
 
 export default codegenNativeComponent<NativeProps>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -412,6 +412,92 @@ export interface DocumentClassificationErrorFlags {
 }
 
 // ============================================================================
+// CAMERA CONTROLS TYPES (Phase 3)
+// ============================================================================
+// NOTE: `LensFacing` is defined here (rather than imported from
+// `VisionCameraTypes.ts`, which already has an equivalent `CameraFacing` type)
+// to avoid a circular import — `VisionCameraTypes.ts` imports `TemplateData`
+// from this file, so importing back from it here would create a cycle.
+// `VisionCameraTypes.ts`'s `CameraFacing` aliases this type instead.
+
+/**
+ * Camera lens facing direction.
+ * @type {'back' | 'front'}
+ */
+export type LensFacing = 'back' | 'front';
+
+/**
+ * Physical lens kind, as reported by `VisionCore.getCameraCapabilities()`.
+ * @type {'ultraWide' | 'wide' | 'telephoto' | 'unknown'}
+ */
+export type LensKind = 'ultraWide' | 'wide' | 'telephoto' | 'unknown';
+
+/**
+ * Camera focus mode.
+ * @type {'continuous' | 'single' | 'locked'}
+ * @description 'continuous' (AF-C), 'single' (AF-S), or 'locked' (focus fixed at its current position).
+ */
+export type FocusMode = 'continuous' | 'single' | 'locked';
+
+/**
+ * Camera session status, reported via `onCameraStateChanged`.
+ * @type {'idle' | 'starting' | 'running' | 'interrupted' | 'error'}
+ */
+export type CameraStatus = 'idle' | 'starting' | 'running' | 'interrupted' | 'error';
+
+/**
+ * Camera error/warning codes.
+ * @type {'permission-denied' | 'lens-unavailable' | 'configuration-failed'}
+ * @description Used for both `errorCode` (fatal, `status === 'error'`) and
+ * `warningCode` (non-fatal, e.g. an unpinnable `pinnedLensId` falling back to Auto).
+ */
+export type CameraErrorCode =
+  | 'permission-denied'
+  | 'lens-unavailable'
+  | 'configuration-failed';
+
+/**
+ * Describes a single physical or logical camera lens.
+ * @interface
+ */
+export interface Lens {
+  /** Stable identifier for this lens, used with `pinnedLensId`. */
+  id: string;
+  /** Physical lens kind (ultra-wide / wide / telephoto / unknown). */
+  kind: LensKind;
+  /** Which physical camera position this lens belongs to. */
+  facing: LensFacing;
+  /** Minimum supported wide-normalized zoom ratio for this lens. */
+  minZoomRatio: number;
+  /** Maximum supported wide-normalized zoom ratio for this lens. */
+  maxZoomRatio: number;
+  /** Zoom ratios at which the OS switches to/from this lens (logical lenses only). */
+  zoomSwitchPoints: number[];
+  /** Whether this lens has an attached flash/torch unit. */
+  hasFlash: boolean;
+  /** Whether this is a logical (multi-camera fusion) lens vs. a single physical lens. */
+  isLogical: boolean;
+  /** Whether this lens can be targeted directly via `pinnedLensId`. */
+  isPinnable: boolean;
+}
+
+/**
+ * Snapshot of the device's camera capabilities, returned by
+ * `VisionCore.getCameraCapabilities()`.
+ * @interface
+ */
+export interface CameraCapabilities {
+  /** All lenses available on the device, across both facings. */
+  lenses: Lens[];
+  /** Available zoom stops (wide-normalized ratios), keyed by facing. */
+  zoomStops: Record<LensFacing, number[]>;
+  /** Whether a torch/flash is available, keyed by facing. */
+  hasTorch: Record<LensFacing, boolean>;
+  /** Whether tap-to-focus is supported, keyed by facing. */
+  supportsFocusPoint: Record<LensFacing, boolean>;
+}
+
+// ============================================================================
 // MODEL MANAGEMENT TYPES
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Consolidates the Phase 3 camera-controls work with the native SDK version bumps it depends on.

**Native SDK bumps**
- `android/build.gradle`: JitPack `v2.4.56` → `v2.5.0`
- `react-native-vision-sdk.podspec`: `VisionSDK` / `VisionSDK/Dimensioning` `2.3.14` → `2.4.0`
- `example/ios/Podfile` + regenerated `Podfile.lock`: matching `2.4.0` pins

**Camera controls (Phase 3)**
Bridges the CameraSession camera-controls surface (zoom / torch / focus capabilities) through to RN:
- Android: `VisionCameraViewManager.kt`, `VisionSdkModule.kt`
- iOS: `RNVisionCameraView.swift`, `VisionSdkModule.swift`, Fabric component view
- JS: `useCameraControls` hook, `VisionCamera` / `VisionCoreWrapper` wiring, codegen specs and types
- Example: `CameraControlsQAScreen` + `ScannerScreen` integration

## Verification

| Check | Result |
|---|---|
| `yarn typescript` | ✅ pass |
| `yarn test` | ✅ 27 passed / 4 suites (incl. 3 new camera-controls suites) |
| `yarn prepare` (bob build) | ✅ pass |
| `yarn lint` (changed files) | ✅ 0 errors |
| `pod install` @ VisionSDK 2.4.0 | ✅ resolves, lock regenerated |
| JitPack `v2.5.0` | ✅ built, modules published |
| CocoaPods `VisionSDK 2.4.0` | ✅ live on trunk |

