### PR TITLE
chore: bump package version to 3.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-sdk",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "VisionSDK for React Native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
Bumps `package.json` from `3.10.0` to `3.11.0`.

### Context — the last Release run failed

The `Release` workflow that fired on the #194 merge failed at the publish step:

```
npm error You cannot publish over the previously published versions: 3.11.0.
```
