### PR TITLE
chore(ios): bump VisionSDK pod to 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-sdk",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "VisionSDK for React Native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-vision-sdk.podspec
+++ b/react-native-vision-sdk.podspec
@@ -45,9 +45,9 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
   # Core scanner + OCR
-  s.dependency "VisionSDK", "= 2.4.0"
+  s.dependency "VisionSDK", "= 2.4.1"
   # 3-D box measurement — brings MVDimensioningCore.xcframework, ARKit, RealityKit, PostHog
-  s.dependency "VisionSDK/Dimensioning", "= 2.4.0"
+  s.dependency "VisionSDK/Dimensioning", "= 2.4.1"
 
   # New Architecture dependencies
   install_modules_dependencies(s)


### PR DESCRIPTION
## Changes

`react-native-vision-sdk.podspec`:
- `s.dependency "VisionSDK"` 2.4.0 -> 2.4.1
- `s.dependency "VisionSDK/Dimensioning"` 2.4.0 -> 2.4.1

