### PR TITLE
chore: reconcile version with npm and fix the release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # RELEASE_TOKEN is a PAT/GitHub App token allowed to bypass branch
+          # protection on main. The default GITHUB_TOKEN cannot: release-it
+          # pushes the version commit + tag directly to main, and protection
+          # rejects it with GH006 ("Changes must be made through a pull
+          # request") -- AFTER `npm publish` has already run, leaving npm ahead
+          # of git with no tag (this is what happened to 3.14.0 on 2026-08-05).
+          # Falls back to GITHUB_TOKEN so the checkout still works for CI runs
+          # that never reach the push step.
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1870,7 +1870,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-vision-sdk (3.13.0):
+  - react-native-vision-sdk (3.14.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3164,7 +3164,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: 06d59c448da7e34eb05b3fb2189e12f6a30fec57
   React-microtasksnativemodule: d1ee999dc9052e23f6488b730fa2d383a4ea40e5
   react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
-  react-native-vision-sdk: a193deb32ff87acbd7bf9c3f813e3184ad9c8d55
+  react-native-vision-sdk: e089881719d15533a80c9ecb8ce4dcecf76a2e87
   React-NativeModulesApple: 46690a0fe94ec28fc6fc686ec797b911d251ded0
   React-oscompat: 95875e81f5d4b3c7b2c888d5bd2c9d83450d8bdb
   React-perflogger: 2e229bf33e42c094fd64516d89ec1187a2b79b5b

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-sdk",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "VisionSDK for React Native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Why

On 2026-08-05 `release-it` **published 3.14.0 to npm** and then **failed pushing to `main`**:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
 ! [remote rejected] main -> main (protected branch hook declined)
```

release-it rolled the git side back — including deleting the tag it had just created — but **`npm publish` cannot be rolled back**. So since then:

| | |
|---|---|
| npm `dist-tags.latest` | **3.14.0** |
| `main` `package.json` | 3.13.0 |
| `v3.14.0` git tag | *missing* |

And it recurs on every release, because the cause is structural: release-it's order is `npm version` → **`npm publish`** → git commit → git tag → **git push**. The push is the step that fails, and by then the publish has already happened.

## What this does

- **`package.json` → 3.14.0**, matching npm. Also updates `Podfile.lock`, whose local-pod entry derives from it.
- **`release.yml` checks out with `RELEASE_TOKEN`** when present, falling back to `GITHUB_TOKEN`. The default `GITHUB_TOKEN` cannot bypass branch protection, which is precisely why the push was rejected.

The **`v3.14.0` tag has already been pushed separately**, pointing at `f857989` — the commit npm recorded as `gitHead` for the published tarball. Note `package.json` reads 3.13.0 at that commit, because release-it's version-bump commit never landed.

## ⚠️ Required before the next release

Create a **`RELEASE_TOKEN`** secret — a PAT or GitHub App token whose account is permitted to bypass branch protection on `main`. Without it the fallback preserves today's broken behaviour: publish succeeds, push fails, npm drifts ahead of git again.

An alternative worth considering instead: restructure so the version bump lands via PR and publishing triggers off the tag, rather than granting bypass at all. That's a larger change and isn't attempted here.

## Verification

The published 3.14.0 tarball was confirmed to contain the intended natives:

- `com.github.packagexlabs:vision-sdk-android:v2.6.0`
- `VisionSDK` / `VisionSDK/Dimensioning` `= 2.5.0`
- `gitHead: f857989d` — the merge commit of #197

A clean `npm install react-native-vision-sdk@3.14.0` in an empty project resolves and installs correctly, so consumers are unaffected by the git-side inconsistency this PR repairs.
